### PR TITLE
major updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Validation modes](#validation-modes)
   - [isValid](#isvalid)
   - [validate](#validate)
+  - [validOrDefault / validOrFallback](#validordefault--validorfallback)
 - [Error evaluation](#error-evaluation)
 - [Collect all errors](#collect-all-errors)
 - [How to define custom validators](#how-to-define-custom-validators)
@@ -126,6 +127,22 @@ function processIncomingValueAsString(value_: unknown): number {
     return NaN;
   }
 }
+```
+
+### validOrDefault / validOrFallback
+
+> since 4.0.0
+
+Two shortcuts when you don't want to deal with `true`/`false` or try-catch. They don't throw: `validOrDefault` returns the validated value or `undefined`, `validOrFallback` returns the validated value or a fallback you provide.
+
+```ts
+import ti from 'ts-type-inspector';
+
+ti.number.validOrDefault(42);      // 42
+ti.number.validOrDefault('nope');  // undefined
+
+ti.number.validOrFallback(42, 0);     // 42
+ti.number.validOrFallback('nope', 0); // 0
 ```
 
 ## Error evaluation
@@ -301,15 +318,15 @@ cdv.failWhenRequired.isValid(value, { valueRequired: true }); // false
 
 ### External influences and nested validators
 
-Relevant to: Object, Partial, Dictionary, Array, Tuple
+Relevant to: Object, Partial, Dictionary, Array, Tuple, Map, Set
 
-It is possible to pass the external influence parameters to nested validators. For this it is necessary to use a wrapper, which is provided by the main validator.
+Sometimes a nested validator needs the parent's validation params. `ti.nested` (since 4.0.0) wraps a validator and maps the parent params to the nested validator's params. The type of the parent params is **inferred automatically** from the surrounding validator - no annotation, no assertion.
 
 ```ts
-import { DefaultObjectValidator, DefaultStringValidator } from 'ts-type-inspector';
+import { DefaultObjectValidator, DefaultStringValidator, ti } from 'ts-type-inspector';
 
 export type CommonData = {
-  data: string | undefined;
+  data: string;
 };
 export type SpecialStringValidationParams = {
   notEmpty?: boolean;
@@ -336,8 +353,11 @@ export class CommonDataValidator extends DefaultObjectValidator<
 > {
   constructor() {
     super({
-      data: (validateWith, validationParams) =>
-        validateWith(new SpecialStringValidator(), validationParams?.dataParams)
+      // params_ is automatically typed as CommonDataValidationParams | undefined
+      data: ti.nested(
+        new SpecialStringValidator(),
+        (params_) => params_?.dataParams
+      )
     });
   }
 }
@@ -346,6 +366,8 @@ const cdv = new CommonDataValidator();
 cdv.isValid({ data: '' }); // true
 cdv.isValid({ data: '' }, { dataParams: { notEmpty: true } }); // false
 ```
+
+> `ti.nested` only makes sense inside a container (object, partial, dictionary, array, tuple, map, set) - it is not a standalone validator.
 
 ## Predefined validators
 
@@ -427,6 +449,7 @@ Validator for object based values.
 | Condition | Description |
 |---|---|
 | noOverload | reject objects that contain more keys than have been validated. **USE FOR POJOs ONLY!**. Getters/setters or private properties can produce false negatives. |
+| rejectArray | reject array values (arrays are objects too and pass by default) |
 
 ```ts
 import ti from 'ts-type-inspector';
@@ -440,6 +463,17 @@ ti.object<DataInterface>({
   prop1: ti.string,
   prop2: ti.number
 });
+```
+
+Since 4.0.0 you can get back the validators you defined for the properties via `prop` / `props` (works on object and partial):
+
+```ts
+import ti from 'ts-type-inspector';
+
+const validator = ti.object({ prop1: ti.string, prop2: ti.number });
+
+validator.prop('prop1'); // the validator defined for prop1
+validator.props();       // the whole property validators map
 ```
 
 ### Partial

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [isValid](#isvalid)
   - [validate](#validate)
 - [Error evaluation](#error-evaluation)
+- [Collect all errors](#collect-all-errors)
 - [How to define custom validators](#how-to-define-custom-validators)
   - [Create specialized (data type related) validators](#create-specialized-data-type-related-validators)
   - [Validation based on external influences](#validation-based-on-external-influences)
@@ -34,6 +35,12 @@
   - [Enum](#enum)
   - [Exclude](#exclude)
   - [Boolean](#boolean)
+  - [BigInt](#bigint)
+  - [Symbol](#symbol)
+  - [Instance](#instance)
+  - [Map](#map)
+  - [Set](#set)
+  - [Lazy](#lazy)
   - [Undefined](#undefined)
   - [Null](#null)
   - [Nullish](#nullish)
@@ -167,6 +174,33 @@ Parameter | Description
 &rarr; `propertyTrace` | equivalent to `propertyPath` but stored as array >> `[propertyX, 5, propertyY]`
 &rarr; `subErrors` | Each chained validator has its own validation error instance. Errors are caught, processed/expanded and then thrown again by parent validators. Each validator captures thrown child validation errors.
 &rarr; `message` | Specific message describing the invalidity
+
+## Collect all errors
+
+By default validation stops at the first invalidity. If you want ALL of them instead (e.g. to show every invalid form field at once) add `.aggregate` to a container validator (object, partial, array, tuple, dictionary, map, set). It collects one sub-error per invalid child instead of throwing on the first one.
+
+```ts
+import ti, { flattenValidationError } from 'ts-type-inspector';
+
+const validator = ti.object({
+  name: ti.string,
+  age: ti.number
+}).aggregate;
+
+validator.isValid({ name: 42, age: 'old' }); // false
+
+// flattenValidationError turns the (nested) error into a flat list
+flattenValidationError(validator.validationError);
+/*
+  [
+    { path: 'name', message: 'value is not a string' },
+    { path: 'age', message: 'value is not a number' }
+  ]
+*/
+```
+
+> `.aggregate` only affects container validators. On value validators (string, number, ...) it does nothing.
+> `flattenValidationError` also works without `.aggregate` - then you simply get a single entry.
 
 ## How to define custom validators
 
@@ -357,6 +391,9 @@ Validator for string values.
 | uri | string has to match uri pattern (uses [valid-url](https://www.npmjs.com/package/valid-url)) |
 | url | string has to match url pattern |
 | hex | accept only hexadecimal strings |
+| startsWith | string has to start with the given value |
+| endsWith | string has to end with the given value |
+| includes | string has to contain the given value |
 
 ### Number
 
@@ -376,6 +413,9 @@ Validator for number values.
 | max | reject numbers greater than maximal value |
 | accept | accept specific numbers only |
 | reject | reject specific numbers |
+| integer | accept integers only |
+| safeInteger | accept safe integers only |
+| multipleOf | number has to be a multiple of the given base |
 
 ### Object
 
@@ -722,6 +762,89 @@ Validator for boolean values.
 |---|---|
 | true | only true is valid |
 | false | only false is valid |
+
+### BigInt
+
+> since 4.0.0
+
+Validator for bigint values.
+
+| Condition | Description |
+|---|---|
+| positive | accept positive values only (zero is not positive) |
+| negative | accept negative values only (zero is not negative) |
+| rejectZero | reject 0n |
+| min | reject values less than minimal value |
+| max | reject values greater than maximal value |
+| accept | accept specific values only |
+| reject | reject specific values |
+
+### Symbol
+
+> since 4.0.0
+
+Validator for symbol values.
+
+### Instance
+
+> since 4.0.0
+
+Validator for class instances. Uses the `instanceof` operator.
+
+```ts
+import ti from 'ts-type-inspector';
+
+class Animal {}
+
+ti.instance(Animal);
+// .isValid(new Animal()) ==> true
+```
+
+### Map
+
+> since 4.0.0
+
+Validator for Map values. Each key and value has to match its validator.
+
+```ts
+import ti from 'ts-type-inspector';
+
+ti.map(ti.string, ti.number);
+// .isValid(new Map([['a', 1]])) ==> true
+```
+
+### Set
+
+> since 4.0.0
+
+Validator for Set values. Each item has to match the item validator.
+
+```ts
+import ti from 'ts-type-inspector';
+
+ti.set(ti.number);
+// .isValid(new Set([1, 2, 3])) ==> true
+```
+
+### Lazy
+
+> since 4.0.0
+
+Resolves the validator lazily (on validation). Use this for recursive/self-referential types where the validator has to reference itself.
+
+```ts
+import ti from 'ts-type-inspector';
+
+interface TreeNode {
+  value: number;
+  children: TreeNode[];
+}
+
+const treeValidator = ti.object<TreeNode>({
+  value: ti.number,
+  children: ti.array(ti.lazy(() => treeValidator)) // reference itself
+});
+```
 
 ### Undefined
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ cdv.failWhenRequired.isValid(value, { valueRequired: true }); // false
 
 Relevant to: Object, Partial, Dictionary, Array, Tuple, Map, Set
 
-Sometimes a nested validator needs the parent's validation params. `ti.nested` (since 4.0.0) wraps a validator and maps the parent params to the nested validator's params. The type of the parent params is **inferred automatically** from the surrounding validator - no annotation, no assertion.
+Sometimes a nested validator needs the parent's validation params. `ti.nested` (since 4.0.0) wraps a validator and maps the parent params to the nested validator's params.
 
 ```ts
 import { DefaultObjectValidator, DefaultStringValidator, ti } from 'ts-type-inspector';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-type-inspector",
-  "version": "3.3.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-type-inspector",
-      "version": "3.3.2",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-type-inspector",
-  "version": "3.3.2",
+  "version": "4.0.0",
   "description": "Tool for type safe value validation",
   "files": [
     "dist"

--- a/src/error.ts
+++ b/src/error.ts
@@ -47,3 +47,53 @@ export function isValidationError(
     reason_[VALIDATION_ERROR_MARKER] === true
   );
 }
+
+/**
+ * a single flattened invalidity: the property path (if any) and its message
+ *
+ * @since 4.0.0
+ */
+export type FlatValidationError = {
+  path: string | undefined;
+  message: string;
+};
+
+/**
+ * Flatten a (possibly nested) ValidationError into a list of leaf invalidities,
+ * each with its property path and message. Especially useful together with the
+ * `aggregate` mode, which collects ALL invalidities instead of failing on the
+ * first one - e.g. to render every invalid field of a form at once.
+ *
+ * HINT: for deeply nested aggregate errors the reported path may be that of the
+ * nearest aggregating ancestor rather than the full leaf path.
+ *
+ * @export
+ * @param {ValidationError} error_
+ * @returns {ReadonlyArray<FlatValidationError>}
+ * @since 4.0.0
+ */
+export function flattenValidationError(
+  error_: ValidationError
+): ReadonlyArray<FlatValidationError> {
+  const result: FlatValidationError[] = [];
+
+  const visit = (error: ValidationError): void => {
+    const childErrors = (error.subErrors ?? []).filter(isValidationError);
+
+    if (childErrors.length > 1) {
+      // aggregate branch point -> descend into each collected sibling
+      for (let i = 0; i < childErrors.length; i++) {
+        visit(childErrors[i]);
+      }
+    } else {
+      result.push({
+        path: error.propertyPath,
+        message: error.originalErrorMessage
+      });
+    }
+  };
+
+  visit(error_);
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   DefaultBooleanValidator,
   type BooleanValidator
 } from './validator/boolean.js';
+export { ContainerValidator } from './validator/container.js';
 export {
   DefaultCustomValidator,
   type CustomValidator
@@ -47,6 +48,10 @@ export {
 } from './validator/instance.js';
 export { DefaultLazyValidator, type LazyValidator } from './validator/lazy.js';
 export { DefaultMapValidator, type MapValidator } from './validator/map.js';
+export {
+  DefaultNestedValidator,
+  type NestedValidator
+} from './validator/nested.js';
 export {
   DefaultMethodValidator,
   type MethodValidator
@@ -72,6 +77,7 @@ export {
   DefaultPartialValidator,
   type PartialValidator
 } from './validator/partial.js';
+export { PropertiesValidator } from './validator/properties.js';
 export { DefaultSetValidator, type SetValidator } from './validator/set.js';
 export {
   DefaultStrictValidator,
@@ -91,7 +97,6 @@ export {
 } from './validator/tuple.js';
 export {
   DefaultUndefinedValidator,
-  DefaulUndefinedValidator,
   type UndefinedValidator
 } from './validator/undefined.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,26 @@ import { TypeInspector } from './inspector.js';
 
 export type {
   AnyLike,
-  MethodLike,
   InstanceLike,
+  MethodLike,
   RecordLike
 } from 'ts-lib-extended';
-export { ValidationError, isValidationError } from './error.js';
+export {
+  flattenValidationError,
+  isValidationError,
+  ValidationError,
+  type FlatValidationError
+} from './error.js';
 export type * from './types.js';
 export { DefaultAnyValidator, type AnyValidator } from './validator/any.js';
 export {
   DefaultArrayValidator,
   type ArrayValidator
 } from './validator/array.js';
+export {
+  DefaultBigIntValidator,
+  type BigIntValidator
+} from './validator/bigint.js';
 export {
   DefaultBooleanValidator,
   type BooleanValidator
@@ -32,6 +41,12 @@ export {
   type ExcludeValidator
 } from './validator/exclude.js';
 export { DefaultValidator } from './validator/index.js';
+export {
+  DefaultInstanceValidator,
+  type InstanceValidator
+} from './validator/instance.js';
+export { DefaultLazyValidator, type LazyValidator } from './validator/lazy.js';
+export { DefaultMapValidator, type MapValidator } from './validator/map.js';
 export {
   DefaultMethodValidator,
   type MethodValidator
@@ -57,6 +72,7 @@ export {
   DefaultPartialValidator,
   type PartialValidator
 } from './validator/partial.js';
+export { DefaultSetValidator, type SetValidator } from './validator/set.js';
 export {
   DefaultStrictValidator,
   type StrictValidator
@@ -65,6 +81,10 @@ export {
   DefaultStringValidator,
   type StringValidator
 } from './validator/string.js';
+export {
+  DefaultSymbolValidator,
+  type SymbolValidator
+} from './validator/symbol.js';
 export {
   DefaultTupleValidator,
   type TupleValidator

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -1,5 +1,6 @@
 import type {
   AnyLike,
+  Constructor,
   Dictionary,
   DictionaryValue,
   Enumerable,
@@ -20,10 +21,16 @@ import { DefaultBooleanValidator } from './validator/boolean.js';
 import { DefaultCustomValidator } from './validator/custom.js';
 import { DefaultDateValidator } from './validator/date.js';
 import { DefaultDictionaryValidator } from './validator/dictionary.js';
+import { DefaultBigIntValidator } from './validator/bigint.js';
 import { DefaultEnumValidator } from './validator/enum.js';
 import { DefaultExcludeValidator } from './validator/exclude.js';
 import { DefaultValidator } from './validator/index.js';
+import { DefaultInstanceValidator } from './validator/instance.js';
+import { DefaultLazyValidator } from './validator/lazy.js';
+import { DefaultMapValidator } from './validator/map.js';
 import { DefaultMethodValidator } from './validator/method.js';
+import { DefaultSetValidator } from './validator/set.js';
+import { DefaultSymbolValidator } from './validator/symbol.js';
 import { DefaultNullValidator } from './validator/null.js';
 import { DefaultNullishValidator } from './validator/nullish.js';
 import { DefaultNumberValidator } from './validator/number.js';
@@ -318,5 +325,91 @@ export class TypeInspector {
     ...itemValidators_: TupleItemValidators<Out>
   ): DefaultTupleValidator<Out> {
     return new DefaultTupleValidator<Out>(...itemValidators_);
+  }
+
+  /**
+   * Validate bigint values.
+   *
+   * @public
+   * @readonly
+   * @type {DefaultBigIntValidator}
+   * @since 4.0.0
+   */
+  public get bigint(): DefaultBigIntValidator {
+    return new DefaultBigIntValidator();
+  }
+
+  /**
+   * Validate symbol values.
+   *
+   * @public
+   * @readonly
+   * @type {DefaultSymbolValidator}
+   * @since 4.0.0
+   */
+  public get symbol(): DefaultSymbolValidator {
+    return new DefaultSymbolValidator();
+  }
+
+  /**
+   * Validate class instances through the `instanceof` operator.
+   *
+   * @public
+   * @template Out
+   * @param {Constructor<Out>} constructor_ the class/constructor to check against
+   * @returns {DefaultInstanceValidator<Out>}
+   * @since 4.0.0
+   */
+  public instance<Out>(
+    constructor_: Constructor<Out>
+  ): DefaultInstanceValidator<Out> {
+    return new DefaultInstanceValidator<Out>(constructor_);
+  }
+
+  /**
+   * Validate Map values. Each key and value has to match its validator.
+   *
+   * @public
+   * @template K
+   * @template V
+   * @param {Validator<K>} keyValidator_ validator for the map keys
+   * @param {Validator<V>} valueValidator_ validator for the map values
+   * @returns {DefaultMapValidator<K, V>}
+   * @since 4.0.0
+   */
+  public map<K, V>(
+    keyValidator_: Validator<K>,
+    valueValidator_: Validator<V>
+  ): DefaultMapValidator<K, V> {
+    return new DefaultMapValidator<K, V>(keyValidator_, valueValidator_);
+  }
+
+  /**
+   * Validate Set values. Each item has to match the item validator.
+   *
+   * @public
+   * @template V
+   * @param {Validator<V>} itemValidator_ validator for the set items
+   * @returns {DefaultSetValidator<V>}
+   * @since 4.0.0
+   */
+  public set<V>(itemValidator_: Validator<V>): DefaultSetValidator<V> {
+    return new DefaultSetValidator<V>(itemValidator_);
+  }
+
+  /**
+   * Resolve a validator lazily (on validation). Use this for recursive or
+   * self-referential schemas where the validator has to reference itself.
+   *
+   * @public
+   * @template Out
+   * @param {() => Validator<Out>} validatorFactory_ produces the actual validator on demand
+   * @returns {DefaultLazyValidator<Out>}
+   * @since 4.0.0
+   */
+  public lazy<Out>(
+    validatorFactory_: () => Validator<Out>
+  ): DefaultLazyValidator<Out> {
+    return new DefaultLazyValidator<Out>(validatorFactory_);
   }
 }

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -337,7 +337,7 @@ export class TypeInspector {
   public tuple<const Out extends unknown[]>(
     ...itemValidators_: TupleItemValidators<Out>
   ): DefaultTupleValidator<Out> {
-    return new DefaultTupleValidator(...itemValidators_);
+    return new DefaultTupleValidator(itemValidators_);
   }
 
   /**

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -9,11 +9,13 @@ import type {
 } from 'ts-lib-extended';
 import type {
   CustomValidation,
+  NestedValidationParams,
   PartialPropertyValidators,
   PropertyValidators,
   TupleItemValidators,
   UnionValidators,
-  Validator
+  Validator,
+  ValidatorOut
 } from './types.js';
 import { DefaultAnyValidator } from './validator/any.js';
 import { DefaultArrayValidator } from './validator/array.js';
@@ -28,6 +30,10 @@ import { DefaultValidator } from './validator/index.js';
 import { DefaultInstanceValidator } from './validator/instance.js';
 import { DefaultLazyValidator } from './validator/lazy.js';
 import { DefaultMapValidator } from './validator/map.js';
+import {
+  DefaultNestedValidator,
+  type NestedValidator
+} from './validator/nested.js';
 import { DefaultMethodValidator } from './validator/method.js';
 import { DefaultSetValidator } from './validator/set.js';
 import { DefaultSymbolValidator } from './validator/symbol.js';
@@ -411,5 +417,36 @@ export class TypeInspector {
     validatorFactory_: () => Validator<Out>
   ): DefaultLazyValidator<Out> {
     return new DefaultLazyValidator<Out>(validatorFactory_);
+  }
+
+  /**
+   * Wrap a validator so the parent's validation params get mapped to the nested
+   * validator's params. Use this to forward (and transform) validation params
+   * into nested/sub validators.
+   *
+   * @public
+   * @template Out
+   * @template [ParentValidationParams=unknown] params handed in by the parent validator
+   * @template {Validator<Out>} [V=Validator<Out>] the wrapped validator
+   * @param {V} validator_ the nested validator
+   * @param {(parentParams_: ParentValidationParams | undefined) => NestedValidationParams<V> | undefined} withParams_ maps the parent params to the nested validator's params
+   * @returns {DefaultNestedValidator<Out, ParentValidationParams, V>}
+   * @since 4.0.0
+   */
+  public nested<V extends Validator<unknown>, ParentValidationParams = unknown>(
+    validator_: V,
+    withParams_: (
+      parentParams_: ParentValidationParams | undefined
+    ) => NestedValidationParams<V> | undefined
+  ): NestedValidator<ValidatorOut<V>, ParentValidationParams> {
+    return new DefaultNestedValidator<
+      ValidatorOut<V>,
+      ParentValidationParams,
+      NestedValidationParams<V>
+    >(
+      // safe: V is Validator<ValidatorOut<V>, NestedValidationParams<V>> by construction
+      validator_ as Validator<ValidatorOut<V>, NestedValidationParams<V>>,
+      withParams_
+    );
   }
 }

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -9,13 +9,12 @@ import type {
 } from 'ts-lib-extended';
 import type {
   CustomValidation,
-  NestedValidationParams,
   PartialPropertyValidators,
   PropertyValidators,
   TupleItemValidators,
   UnionValidators,
-  Validator,
-  ValidatorOut
+  ValidationParamsMapper,
+  Validator
 } from './types.js';
 import { DefaultAnyValidator } from './validator/any.js';
 import { DefaultArrayValidator } from './validator/array.js';
@@ -103,7 +102,7 @@ export class TypeInspector {
    * @since 1.0.0
    */
   public get method(): DefaultMethodValidator<MethodLike> {
-    return new DefaultMethodValidator<MethodLike>();
+    return new DefaultMethodValidator();
   }
 
   /**
@@ -164,7 +163,7 @@ export class TypeInspector {
    * @since 1.0.0
    */
   public strict<V extends AnyLike[]>(...values_: V): DefaultStrictValidator<V> {
-    return new DefaultStrictValidator<V>(...values_);
+    return new DefaultStrictValidator(...values_);
   }
 
   /**
@@ -179,7 +178,7 @@ export class TypeInspector {
   public array<const Item>(
     itemValidator_: Validator<Item>
   ): DefaultArrayValidator<Item> {
-    return new DefaultArrayValidator<Item>(itemValidator_);
+    return new DefaultArrayValidator(itemValidator_);
   }
 
   /**
@@ -195,7 +194,7 @@ export class TypeInspector {
   public union<V extends UnionValidators>(
     ...validators_: V
   ): DefaultUnionValidator<V> {
-    return new DefaultUnionValidator<V>(...validators_);
+    return new DefaultUnionValidator(...validators_);
   }
 
   /**
@@ -203,14 +202,18 @@ export class TypeInspector {
    *
    * @public
    * @template {RecordLike} Out
-   * @param {PropertyValidators<Out>} propertyValidators_ Validators for each object property
-   * @returns {DefaultObjectValidator<Out>}
+   * @template {PropertyValidators<Out>} PV the concrete property validators map
+   * @param {PV & PropertyValidators<Out>} propertyValidators_ Validators for each object property
+   * @returns {DefaultObjectValidator<Out, unknown, PV>}
    * @since 1.0.0
    */
-  public object<Out extends RecordLike>(
-    propertyValidators_: PropertyValidators<Out>
-  ): DefaultObjectValidator<Out> {
-    return new DefaultObjectValidator<Out>(propertyValidators_);
+  public object<
+    Out extends RecordLike,
+    PV extends PropertyValidators<Out> = PropertyValidators<Out>
+  >(
+    propertyValidators_: PV & PropertyValidators<Out>
+  ): DefaultObjectValidator<Out, unknown, PV> {
+    return new DefaultObjectValidator(propertyValidators_);
   }
 
   /**
@@ -218,14 +221,18 @@ export class TypeInspector {
    *
    * @public
    * @template {RecordLike} Out
-   * @param {PartialPropertyValidators<Out>} propertyValidators_
-   * @returns {DefaultPartialValidator<Out>}
+   * @template {PartialPropertyValidators<Out>} PV the concrete property validators map
+   * @param {PV & PartialPropertyValidators<Out>} propertyValidators_
+   * @returns {DefaultPartialValidator<Out, unknown, PV>}
    * @since 2.0.0
    */
-  public partial<Out extends RecordLike>(
-    propertyValidators_: PartialPropertyValidators<Out>
-  ): DefaultPartialValidator<Out> {
-    return new DefaultPartialValidator<Out>(propertyValidators_);
+  public partial<
+    Out extends RecordLike,
+    PV extends PartialPropertyValidators<Out> = PartialPropertyValidators<Out>
+  >(
+    propertyValidators_: PV & PartialPropertyValidators<Out>
+  ): DefaultPartialValidator<Out, unknown, PV> {
+    return new DefaultPartialValidator(propertyValidators_);
   }
 
   /**
@@ -240,7 +247,7 @@ export class TypeInspector {
   public dictionary<V extends Dictionary>(
     itemValidator_: Validator<DictionaryValue<V>>
   ): DefaultDictionaryValidator<V> {
-    return new DefaultDictionaryValidator<V>(itemValidator_);
+    return new DefaultDictionaryValidator(itemValidator_);
   }
 
   /**
@@ -327,10 +334,10 @@ export class TypeInspector {
    * @returns {DefaultTupleValidator<Out>}
    * @since 3.0.0
    */
-  public tuple<Out extends unknown[]>(
+  public tuple<const Out extends unknown[]>(
     ...itemValidators_: TupleItemValidators<Out>
   ): DefaultTupleValidator<Out> {
-    return new DefaultTupleValidator<Out>(...itemValidators_);
+    return new DefaultTupleValidator(...itemValidators_);
   }
 
   /**
@@ -369,7 +376,7 @@ export class TypeInspector {
   public instance<Out>(
     constructor_: Constructor<Out>
   ): DefaultInstanceValidator<Out> {
-    return new DefaultInstanceValidator<Out>(constructor_);
+    return new DefaultInstanceValidator(constructor_);
   }
 
   /**
@@ -387,7 +394,7 @@ export class TypeInspector {
     keyValidator_: Validator<K>,
     valueValidator_: Validator<V>
   ): DefaultMapValidator<K, V> {
-    return new DefaultMapValidator<K, V>(keyValidator_, valueValidator_);
+    return new DefaultMapValidator(keyValidator_, valueValidator_);
   }
 
   /**
@@ -400,7 +407,7 @@ export class TypeInspector {
    * @since 4.0.0
    */
   public set<V>(itemValidator_: Validator<V>): DefaultSetValidator<V> {
-    return new DefaultSetValidator<V>(itemValidator_);
+    return new DefaultSetValidator(itemValidator_);
   }
 
   /**
@@ -416,7 +423,7 @@ export class TypeInspector {
   public lazy<Out>(
     validatorFactory_: () => Validator<Out>
   ): DefaultLazyValidator<Out> {
-    return new DefaultLazyValidator<Out>(validatorFactory_);
+    return new DefaultLazyValidator(validatorFactory_);
   }
 
   /**
@@ -425,28 +432,25 @@ export class TypeInspector {
    * into nested/sub validators.
    *
    * @public
-   * @template Out
+   * @template Out the value type the wrapped validator produces
+   * @template ChildValidationParams params the wrapped validator expects
    * @template [ParentValidationParams=unknown] params handed in by the parent validator
-   * @template {Validator<Out>} [V=Validator<Out>] the wrapped validator
-   * @param {V} validator_ the nested validator
-   * @param {(parentParams_: ParentValidationParams | undefined) => NestedValidationParams<V> | undefined} withParams_ maps the parent params to the nested validator's params
-   * @returns {DefaultNestedValidator<Out, ParentValidationParams, V>}
+   * @param {Validator<Out, ChildValidationParams>} validator_ the nested validator
+   * @param {ValidationParamsMapper<ChildValidationParams, ParentValidationParams>} withParams_ maps the parent params to the nested validator's params
+   * @returns {NestedValidator<Out, ParentValidationParams>}
    * @since 4.0.0
    */
-  public nested<V extends Validator<unknown>, ParentValidationParams = unknown>(
-    validator_: V,
-    withParams_: (
-      parentParams_: ParentValidationParams | undefined
-    ) => NestedValidationParams<V> | undefined
-  ): NestedValidator<ValidatorOut<V>, ParentValidationParams> {
+  public nested<Out, ChildValidationParams, ParentValidationParams = unknown>(
+    validator_: Validator<Out, ChildValidationParams>,
+    withParams_: ValidationParamsMapper<
+      ChildValidationParams,
+      ParentValidationParams
+    >
+  ): NestedValidator<Out, ParentValidationParams> {
     return new DefaultNestedValidator<
-      ValidatorOut<V>,
+      Out,
       ParentValidationParams,
-      NestedValidationParams<V>
-    >(
-      // safe: V is Validator<ValidatorOut<V>, NestedValidationParams<V>> by construction
-      validator_ as Validator<ValidatorOut<V>, NestedValidationParams<V>>,
-      withParams_
-    );
+      ChildValidationParams
+    >(validator_, withParams_);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { ArrayItem, MinArray, RecordLike } from 'ts-lib-extended';
 import type { ValidationError } from './error.js';
+import type { NestedValidator } from './validator/nested.js';
 
 export type CustomValidation<V, ValidationParams = unknown> = (
   value_: V,
@@ -52,28 +53,51 @@ export interface Validator<Out, ValidationParams = unknown> {
    * @returns {value_ is Out} true if valid; false if invalid; this is a type predicate - asserted type will be associated to value if true
    */
   isValid(value_: unknown, params_?: ValidationParams): value_ is Out;
+  /**
+   * validate value; return the validated value (same reference) when valid, else undefined
+   *
+   * @param {unknown} value_
+   * @param {?ValidationParams} [params_]
+   * @returns {Out | undefined}
+   * @since 4.0.0
+   */
+  validOrDefault(value_: unknown, params_?: ValidationParams): Out | undefined;
+  /**
+   * validate value; return the validated value (same reference) when valid, else the given fallback
+   *
+   * @param {unknown} value_
+   * @param {Out} fallback_
+   * @param {?ValidationParams} [params_]
+   * @returns {Out}
+   * @since 4.0.0
+   */
+  validOrFallback(
+    value_: unknown,
+    fallback_: Out,
+    params_?: ValidationParams
+  ): Out;
 }
 
 export type NestedValidationParams<CV extends Validator<unknown>> =
   CV extends Validator<unknown, infer P> ? P : never;
-export type NestedValidator<Out, ValidationParams> =
+export type ValidatorOut<V extends Validator<unknown>> =
+  V extends Validator<infer Out> ? Out : never;
+
+/**
+ * A property/item validator: either a plain validator or a {@link NestedValidator}
+ * (created via `ti.nested`) that forwards the parent's validation params.
+ *
+ * @since 4.0.0
+ */
+export type PropertyValidator<Out, ParentValidationParams = unknown> =
   | Validator<Out>
-  | ((
-      validateWith_: <
-        CV extends Validator<Out>,
-        P extends NestedValidationParams<CV>
-      >(
-        validator_: CV,
-        params_?: P
-      ) => CV,
-      params_?: ValidationParams
-    ) => ReturnType<typeof validateWith_>);
+  | NestedValidator<Out, ParentValidationParams>;
 
 export type PropertyValidators<
   V extends RecordLike,
   ValidationParams = unknown
 > = {
-  readonly [key in keyof V]-?: NestedValidator<V[key], ValidationParams>;
+  readonly [key in keyof V]-?: PropertyValidator<V[key], ValidationParams>;
 };
 
 export type PartialPropertyValidators<
@@ -96,5 +120,5 @@ export type TupleItemValidators<
   A extends unknown[],
   ValidationParams = unknown
 > = {
-  [index in keyof A]: NestedValidator<A[index], ValidationParams>;
+  [index in keyof A]: PropertyValidator<A[index], ValidationParams>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,16 @@ export type NestedValidationParams<CV extends Validator<unknown>> =
   CV extends Validator<unknown, infer P> ? P : never;
 export type ValidatorOut<V extends Validator<unknown>> =
   V extends Validator<infer Out> ? Out : never;
+/**
+ * Maps a parent validator's params to the params a (nested) child validator
+ * expects. This is the signature of the conversion callback used by `ti.nested`.
+ *
+ * @since 4.0.0
+ */
+export type ValidationParamsMapper<
+  ValidationParams,
+  ParentValidationParams = unknown
+> = (parentParams_?: ParentValidationParams) => ValidationParams | undefined;
 
 /**
  * A property/item validator: either a plain validator or a {@link NestedValidator}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type { RecordLike } from 'ts-lib-extended';
  * @template {object} [T=RecordLike]
  * @param {unknown} value_
  * @returns {value_ is T}
- * @since 4.0.0
+ * @since 3.4.0
  */
 export function isObject<T extends object = RecordLike>(
   value_: unknown

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import type { RecordLike } from 'ts-lib-extended';
  * @template {object} [T=RecordLike]
  * @param {unknown} value_
  * @returns {value_ is T}
- * @since 3.4.0
+ * @since 4.0.0
  */
 export function isObject<T extends object = RecordLike>(
   value_: unknown

--- a/src/validator/array.ts
+++ b/src/validator/array.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from '@/error.js';
 import type { NestedValidator, Validator } from '@/types.js';
 import { DefaultValidator } from './index.js';
 
@@ -11,8 +12,10 @@ import { DefaultValidator } from './index.js';
  * @extends {Validator<Out[], ValidationParams>}
  * @since 1.0.0
  */
-export interface ArrayValidator<Out, ValidationParams = unknown>
-  extends Validator<Out[], ValidationParams> {
+export interface ArrayValidator<
+  Out,
+  ValidationParams = unknown
+> extends Validator<Out[], ValidationParams> {
   /**
    * validate exact array length
    *
@@ -104,12 +107,26 @@ export class DefaultArrayValidator<const Out, ValidationParams = unknown>
       this.throwValidationError('value is not an array');
     }
 
+    const errors: ValidationError[] = [];
+
     for (let i = 0; i < value_.length; i++) {
       try {
         this.validateNested(value_[i], this._itemValidator, params_);
       } catch (reason_) {
-        this.rethrowError(reason_, i);
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, i));
+        } else {
+          this.rethrowError(reason_, i);
+        }
       }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more items are invalid',
+        undefined,
+        errors
+      );
     }
 
     return value_ as Out[];

--- a/src/validator/array.ts
+++ b/src/validator/array.ts
@@ -1,6 +1,6 @@
 import type { ValidationError } from '@/error.js';
-import type { NestedValidator, Validator } from '@/types.js';
-import { DefaultValidator } from './index.js';
+import type { PropertyValidator, Validator } from '@/types.js';
+import { ContainerValidator } from './container.js';
 
 /**
  * Validator for array values
@@ -65,16 +65,16 @@ export interface ArrayValidator<
  * @class DefaultArrayValidator
  * @template Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Out[], ValidationParams>}
+ * @extends {ContainerValidator<Out[], ValidationParams>}
  * @implements {ArrayValidator<Out, ValidationParams>}
  * @since 1.0.0
  */
 export class DefaultArrayValidator<const Out, ValidationParams = unknown>
-  extends DefaultValidator<Out[], ValidationParams>
+  extends ContainerValidator<Out[], ValidationParams>
   implements ArrayValidator<Out, ValidationParams>
 {
   constructor(
-    private readonly _itemValidator: NestedValidator<Out, ValidationParams>
+    private readonly _itemValidator: PropertyValidator<Out, ValidationParams>
   ) {
     super();
   }
@@ -110,24 +110,10 @@ export class DefaultArrayValidator<const Out, ValidationParams = unknown>
     const errors: ValidationError[] = [];
 
     for (let i = 0; i < value_.length; i++) {
-      try {
-        this.validateNested(value_[i], this._itemValidator, params_);
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, i));
-        } else {
-          this.rethrowError(reason_, i);
-        }
-      }
+      this.validateChild(errors, () => value_[i], this._itemValidator, i, params_);
     }
 
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more items are invalid',
-        undefined,
-        errors
-      );
-    }
+    this.throwOnErrors(errors, 'one or more items are invalid');
 
     return value_ as Out[];
   }

--- a/src/validator/bigint.ts
+++ b/src/validator/bigint.ts
@@ -1,0 +1,175 @@
+import type { Validator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator for bigint values
+ *
+ * @export
+ * @interface BigIntValidator
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<bigint, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface BigIntValidator<ValidationParams = unknown> extends Validator<
+  bigint,
+  ValidationParams
+> {
+  /**
+   * accept positive values only (zero is not positive)
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get positive(): this;
+  /**
+   * accept negative values only (zero is not negative)
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get negative(): this;
+  /**
+   * reject 0n
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get rejectZero(): this;
+  /**
+   * validate minimum value
+   *
+   * @param {bigint} min_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  min(min_: bigint): this;
+  /**
+   * validate maximum value
+   *
+   * @param {bigint} max_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  max(max_: bigint): this;
+  /**
+   * define accepted values
+   *
+   * @param {...ReadonlyArray<bigint>} values_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  accept(...values_: ReadonlyArray<bigint>): this;
+  /**
+   * define rejected values
+   *
+   * @param {...ReadonlyArray<bigint>} values_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  reject(...values_: ReadonlyArray<bigint>): this;
+}
+
+/**
+ * Validator for bigint values
+ *
+ * @export
+ * @class DefaultBigIntValidator
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<bigint, ValidationParams>}
+ * @implements {BigIntValidator<ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultBigIntValidator<ValidationParams = unknown>
+  extends DefaultValidator<bigint, ValidationParams>
+  implements BigIntValidator<ValidationParams>
+{
+  public get positive(): this {
+    return this.setupCondition((value_) => this.checkPositive(value_));
+  }
+
+  public get negative(): this {
+    return this.setupCondition((value_) => this.checkNegative(value_));
+  }
+
+  public get rejectZero(): this {
+    return this.setupCondition((value_) => this.checkZero(value_));
+  }
+
+  public min(min_: bigint): this {
+    return this.setupCondition((value_) => this.checkMin(value_, min_));
+  }
+
+  public max(max_: bigint): this {
+    return this.setupCondition((value_) => this.checkMax(value_, max_));
+  }
+
+  public accept(...values_: ReadonlyArray<bigint>): this {
+    return this.setupCondition((value_) => this.checkAccepted(value_, values_));
+  }
+
+  public reject(...values_: ReadonlyArray<bigint>): this {
+    return this.setupCondition((value_) => this.checkRejected(value_, values_));
+  }
+
+  protected validateBaseType(
+    value_: unknown,
+    _params_?: ValidationParams
+  ): bigint {
+    if (typeof value_ === 'bigint') {
+      return value_;
+    }
+
+    this.throwValidationError('value is not a bigint');
+  }
+
+  private checkPositive(value_: bigint): void {
+    if (value_ <= 0n) {
+      this.throwValidationError('bigint is not positive');
+    }
+  }
+
+  private checkNegative(value_: bigint): void {
+    if (value_ >= 0n) {
+      this.throwValidationError('bigint is not negative');
+    }
+  }
+
+  private checkZero(value_: bigint): void {
+    if (value_ === 0n) {
+      this.throwValidationError('bigint is 0');
+    }
+  }
+
+  private checkMin(value_: bigint, min_: bigint): void {
+    if (value_ < min_) {
+      this.throwValidationError('bigint is less than minimum');
+    }
+  }
+
+  private checkMax(value_: bigint, max_: bigint): void {
+    if (value_ > max_) {
+      this.throwValidationError('bigint is greater than maximum');
+    }
+  }
+
+  private checkAccepted(
+    value_: bigint,
+    accepted_: ReadonlyArray<bigint>
+  ): void {
+    if (!accepted_.includes(value_)) {
+      this.throwValidationError('bigint is not accepted');
+    }
+  }
+
+  private checkRejected(
+    value_: bigint,
+    rejected_: ReadonlyArray<bigint>
+  ): void {
+    if (rejected_.includes(value_)) {
+      this.throwValidationError('bigint is rejected');
+    }
+  }
+}

--- a/src/validator/container.ts
+++ b/src/validator/container.ts
@@ -1,0 +1,121 @@
+import { ValidationError } from '@/error.js';
+import type { PropertyValidator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+import { isNestedValidator } from './nested.js';
+
+/**
+ * Base class for validators that contain/iterate nested validators (object,
+ * partial, array, tuple, dictionary, map, set). Holds the shared logic for
+ * forwarding params into nested validators and for the opt-in "aggregate"
+ * (collect-all) mode.
+ *
+ * Value validators (string, number, ...) extend {@link DefaultValidator}
+ * directly and therefore do NOT expose `aggregate` - it would be meaningless
+ * for them.
+ *
+ * @export
+ * @abstract
+ * @class ContainerValidator
+ * @template Out
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export abstract class ContainerValidator<
+  Out,
+  ValidationParams = unknown
+> extends DefaultValidator<Out, ValidationParams> {
+  private _aggregateErrors = false;
+
+  /**
+   * Collect ALL nested invalidities instead of failing on the first one.
+   * The thrown ValidationError carries one sub-error per invalid child.
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  public get aggregate(): this {
+    this._aggregateErrors = true;
+    return this;
+  }
+
+  /**
+   * Validate a single nested child. In aggregate mode the invalidity is
+   * collected into `errors_`; otherwise it is rethrown immediately (fail fast).
+   *
+   * The child value is read lazily via `getValue_` so that throwing getters are
+   * caught and turned into proper validation errors.
+   *
+   * @template ChildOut
+   * @param {ValidationError[]} errors_ collector for aggregate mode
+   * @param {() => unknown} getValue_ reads the child value (inside the try)
+   * @param {PropertyValidator<ChildOut, ValidationParams>} propertyValidator_
+   * @param {PropertyKey | undefined} trace_ property key / index for the error path
+   * @param {?ValidationParams} [params_]
+   * @since 4.0.0
+   */
+  protected validateChild<ChildOut>(
+    errors_: ValidationError[],
+    getValue_: () => unknown,
+    propertyValidator_: PropertyValidator<ChildOut, ValidationParams>,
+    trace_: PropertyKey | undefined,
+    params_?: ValidationParams
+  ): void {
+    try {
+      this.validateNested(getValue_(), propertyValidator_, params_);
+    } catch (reason_) {
+      if (this._aggregateErrors) {
+        errors_.push(this.collectNestedError(reason_, trace_));
+      } else {
+        this.rethrowError(reason_, trace_);
+      }
+    }
+  }
+
+  /**
+   * Throw an aggregate ValidationError if any invalidities were collected.
+   *
+   * @param {ReadonlyArray<ValidationError>} errors_
+   * @param {string} message_ message of the aggregate error
+   * @since 4.0.0
+   */
+  protected throwOnErrors(
+    errors_: ReadonlyArray<ValidationError>,
+    message_: string
+  ): void {
+    if (errors_.length > 0) {
+      this.throwValidationError(message_, undefined, errors_);
+    }
+  }
+
+  private validateNested<NestedOut>(
+    value_: unknown,
+    propertyValidator_: PropertyValidator<NestedOut, ValidationParams>,
+    params_?: ValidationParams
+  ): void {
+    if (isNestedValidator(propertyValidator_)) {
+      // ti.nested: maps + forwards the parent's params to the wrapped validator
+      propertyValidator_.validateNested(value_, params_);
+    } else {
+      // plain validator: forward params too (it ignores them if unused)
+      propertyValidator_.validate(value_, params_);
+    }
+  }
+
+  private collectNestedError(
+    reason_: unknown,
+    trace_?: PropertyKey
+  ): ValidationError {
+    const propertyTraces: PropertyKey[] = trace_ === undefined ? [] : [trace_];
+    const { error, originalMessage } = this.detectError(
+      reason_,
+      propertyTraces
+    );
+    return new ValidationError(
+      originalMessage ?? error.message,
+      propertyTraces,
+      [error]
+    );
+  }
+}

--- a/src/validator/container.ts
+++ b/src/validator/container.ts
@@ -95,11 +95,13 @@ export abstract class ContainerValidator<
     params_?: ValidationParams
   ): void {
     if (isNestedValidator(propertyValidator_)) {
-      // ti.nested: maps + forwards the parent's params to the wrapped validator
+      // ti.nested: the conversion point that maps + forwards the parent's params
+      // to the wrapped validator
       propertyValidator_.validateNested(value_, params_);
     } else {
-      // plain validator: forward params too (it ignores them if unused)
-      propertyValidator_.validate(value_, params_);
+      // plain validator: without a conversion point (ti.nested) the parent's
+      // params do not match the child's params, so none are passed
+      propertyValidator_.validate(value_);
     }
   }
 

--- a/src/validator/dictionary.ts
+++ b/src/validator/dictionary.ts
@@ -1,10 +1,11 @@
+import type { ValidationError } from '@/error.js';
+import type { NestedValidator, Validator } from '@/types.js';
+import { isObject } from '@/utils.js';
 import type {
   Dictionary,
   DictionaryKey,
   DictionaryValue
 } from 'ts-lib-extended';
-import type { NestedValidator, Validator } from '@/types.js';
-import { isObject } from '@/utils.js';
 import { DefaultValidator } from './index.js';
 
 /**
@@ -43,14 +44,17 @@ export interface DictionaryValidator<
  * @since 1.0.0
  */
 export class DefaultDictionaryValidator<
-    Out extends Dictionary,
-    ValidationParams = unknown
-  >
+  Out extends Dictionary,
+  ValidationParams = unknown
+>
   extends DefaultValidator<Out, ValidationParams>
   implements DictionaryValidator<Out, ValidationParams>
 {
   constructor(
-    private readonly _itemValidator: NestedValidator<DictionaryValue<Out>, ValidationParams>
+    private readonly _itemValidator: NestedValidator<
+      DictionaryValue<Out>,
+      ValidationParams
+    >
   ) {
     super();
   }
@@ -59,20 +63,35 @@ export class DefaultDictionaryValidator<
     return this.setupCondition((value_) => this.checkKeys(value_, validator_));
   }
 
-  protected validateBaseType(
-    value_: unknown,
-    params_?: ValidationParams
-  ): Out {
+  protected validateBaseType(value_: unknown, params_?: ValidationParams): Out {
     if (!isObject<Dictionary<unknown>>(value_)) {
       this.throwValidationError('value is not a dictionary');
     }
 
+    const errors: ValidationError[] = [];
+
     for (const dictionaryKey in value_) {
       try {
-        this.validateNested(value_[dictionaryKey], this._itemValidator, params_);
+        this.validateNested(
+          value_[dictionaryKey],
+          this._itemValidator,
+          params_
+        );
       } catch (reason_) {
-        this.rethrowError(reason_, dictionaryKey);
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, dictionaryKey));
+        } else {
+          this.rethrowError(reason_, dictionaryKey);
+        }
       }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more values are invalid',
+        undefined,
+        errors
+      );
     }
 
     return value_ as Out;

--- a/src/validator/dictionary.ts
+++ b/src/validator/dictionary.ts
@@ -1,12 +1,12 @@
 import type { ValidationError } from '@/error.js';
-import type { NestedValidator, Validator } from '@/types.js';
+import type { PropertyValidator, Validator } from '@/types.js';
 import { isObject } from '@/utils.js';
 import type {
   Dictionary,
   DictionaryKey,
   DictionaryValue
 } from 'ts-lib-extended';
-import { DefaultValidator } from './index.js';
+import { ContainerValidator } from './container.js';
 
 /**
  * Validator for dictionary objects
@@ -39,7 +39,7 @@ export interface DictionaryValidator<
  * @class DefaultDictionaryValidator
  * @template {Dictionary} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Out, ValidationParams>}
+ * @extends {ContainerValidator<Out, ValidationParams>}
  * @implements {DictionaryValidator<Out, ValidationParams>}
  * @since 1.0.0
  */
@@ -47,11 +47,11 @@ export class DefaultDictionaryValidator<
   Out extends Dictionary,
   ValidationParams = unknown
 >
-  extends DefaultValidator<Out, ValidationParams>
+  extends ContainerValidator<Out, ValidationParams>
   implements DictionaryValidator<Out, ValidationParams>
 {
   constructor(
-    private readonly _itemValidator: NestedValidator<
+    private readonly _itemValidator: PropertyValidator<
       DictionaryValue<Out>,
       ValidationParams
     >
@@ -71,28 +71,16 @@ export class DefaultDictionaryValidator<
     const errors: ValidationError[] = [];
 
     for (const dictionaryKey in value_) {
-      try {
-        this.validateNested(
-          value_[dictionaryKey],
-          this._itemValidator,
-          params_
-        );
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, dictionaryKey));
-        } else {
-          this.rethrowError(reason_, dictionaryKey);
-        }
-      }
-    }
-
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more values are invalid',
-        undefined,
-        errors
+      this.validateChild(
+        errors,
+        () => value_[dictionaryKey],
+        this._itemValidator,
+        dictionaryKey,
+        params_
       );
     }
+
+    this.throwOnErrors(errors, 'one or more values are invalid');
 
     return value_ as Out;
   }

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -19,9 +19,10 @@ import type {
  * @implements {Validator<Out, ValidationParams>}
  * @since 1.0.0
  */
-export abstract class DefaultValidator<Out, ValidationParams = unknown>
-  implements Validator<Out, ValidationParams>
-{
+export abstract class DefaultValidator<
+  Out,
+  ValidationParams = unknown
+> implements Validator<Out, ValidationParams> {
   private _validationError: ValidationError | undefined;
   private readonly _customValidations: CustomValidation<
     Out,
@@ -30,14 +31,32 @@ export abstract class DefaultValidator<Out, ValidationParams = unknown>
   private readonly _errorHandlers: ValidationErrorHandler<ValidationParams>[];
   private readonly _conditions: ValidationCondition<Out, ValidationParams>[];
 
+  private _aggregateErrors: boolean;
+
   constructor() {
     this._conditions = [];
     this._customValidations = [];
     this._errorHandlers = [];
+    this._aggregateErrors = false;
   }
 
   public get validationError(): ValidationError | undefined {
     return this._validationError;
+  }
+
+  /**
+   * Collect ALL nested invalidities instead of failing on the first one.
+   * Only affects container validators (object, partial, array, tuple,
+   * dictionary, map, set); a no-op on value validators. The thrown
+   * ValidationError carries one sub-error per invalid child.
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  public get aggregate(): this {
+    this._aggregateErrors = true;
+    return this;
   }
 
   public custom(validation_: CustomValidation<Out, ValidationParams>): this {
@@ -125,6 +144,42 @@ export abstract class DefaultValidator<Out, ValidationParams = unknown>
       propertyTraces,
       [error],
       params_
+    );
+  }
+
+  /**
+   * whether this validator collects all nested invalidities (see {@link aggregate})
+   *
+   * @readonly
+   * @type {boolean}
+   * @since 4.0.0
+   */
+  protected get aggregatesErrors(): boolean {
+    return this._aggregateErrors;
+  }
+
+  /**
+   * build (but do NOT throw) a nested ValidationError - used by container
+   * validators to collect all invalidities when {@link aggregate} is active
+   *
+   * @param {unknown} reason_
+   * @param {?PropertyKey} [trace_]
+   * @returns {ValidationError}
+   * @since 4.0.0
+   */
+  protected collectNestedError(
+    reason_: unknown,
+    trace_?: PropertyKey
+  ): ValidationError {
+    const propertyTraces: PropertyKey[] = trace_ === undefined ? [] : [trace_];
+    const { error, originalMessage } = this.detectError(
+      reason_,
+      propertyTraces
+    );
+    return new ValidationError(
+      originalMessage ?? error.message,
+      propertyTraces,
+      [error]
     );
   }
 

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,7 +1,6 @@
 import { ValidationError, isValidationError } from '@/error.js';
 import type {
   CustomValidation,
-  NestedValidator,
   ValidationCondition,
   ValidationErrorHandler,
   Validator
@@ -31,32 +30,14 @@ export abstract class DefaultValidator<
   private readonly _errorHandlers: ValidationErrorHandler<ValidationParams>[];
   private readonly _conditions: ValidationCondition<Out, ValidationParams>[];
 
-  private _aggregateErrors: boolean;
-
   constructor() {
     this._conditions = [];
     this._customValidations = [];
     this._errorHandlers = [];
-    this._aggregateErrors = false;
   }
 
   public get validationError(): ValidationError | undefined {
     return this._validationError;
-  }
-
-  /**
-   * Collect ALL nested invalidities instead of failing on the first one.
-   * Only affects container validators (object, partial, array, tuple,
-   * dictionary, map, set); a no-op on value validators. The thrown
-   * ValidationError carries one sub-error per invalid child.
-   *
-   * @readonly
-   * @type {this}
-   * @since 4.0.0
-   */
-  public get aggregate(): this {
-    this._aggregateErrors = true;
-    return this;
   }
 
   public custom(validation_: CustomValidation<Out, ValidationParams>): this {
@@ -100,6 +81,21 @@ export abstract class DefaultValidator<
     } catch {
       return false;
     }
+  }
+
+  public validOrDefault(
+    value_: unknown,
+    params_?: ValidationParams
+  ): Out | undefined {
+    return this.isValid(value_, params_) ? value_ : undefined;
+  }
+
+  public validOrFallback(
+    value_: unknown,
+    fallback_: Out,
+    params_?: ValidationParams
+  ): Out {
+    return this.validOrDefault(value_, params_) ?? fallback_;
   }
 
   protected abstract validateBaseType(
@@ -147,42 +143,6 @@ export abstract class DefaultValidator<
     );
   }
 
-  /**
-   * whether this validator collects all nested invalidities (see {@link aggregate})
-   *
-   * @readonly
-   * @type {boolean}
-   * @since 4.0.0
-   */
-  protected get aggregatesErrors(): boolean {
-    return this._aggregateErrors;
-  }
-
-  /**
-   * build (but do NOT throw) a nested ValidationError - used by container
-   * validators to collect all invalidities when {@link aggregate} is active
-   *
-   * @param {unknown} reason_
-   * @param {?PropertyKey} [trace_]
-   * @returns {ValidationError}
-   * @since 4.0.0
-   */
-  protected collectNestedError(
-    reason_: unknown,
-    trace_?: PropertyKey
-  ): ValidationError {
-    const propertyTraces: PropertyKey[] = trace_ === undefined ? [] : [trace_];
-    const { error, originalMessage } = this.detectError(
-      reason_,
-      propertyTraces
-    );
-    return new ValidationError(
-      originalMessage ?? error.message,
-      propertyTraces,
-      [error]
-    );
-  }
-
   protected throwValidationError(
     message_: string,
     propertyTrace_?: ReadonlyArray<PropertyKey>,
@@ -215,25 +175,6 @@ export abstract class DefaultValidator<
   ): this {
     this._conditions.push(condition_);
     return this;
-  }
-
-  protected validateNested<NestedOut>(
-    value_: unknown,
-    nestedValidator_: NestedValidator<NestedOut, ValidationParams>,
-    params_?: ValidationParams
-  ) {
-    if (typeof nestedValidator_ === 'function') {
-      let nestedValidationParams: unknown;
-
-      const nestedValidator = nestedValidator_((cval_, cparams_) => {
-        nestedValidationParams = cparams_;
-        return cval_;
-      }, params_);
-
-      nestedValidator.validate(value_, nestedValidationParams);
-    } else {
-      nestedValidator_.validate(value_);
-    }
   }
 
   private hasMessage(value_: unknown): value_ is { message: unknown } {

--- a/src/validator/instance.ts
+++ b/src/validator/instance.ts
@@ -1,0 +1,55 @@
+import type { Validator } from '@/types.js';
+import type { Constructor } from 'ts-lib-extended';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator for class instances (uses the `instanceof` operator)
+ *
+ * @export
+ * @interface InstanceValidator
+ * @template Out
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface InstanceValidator<
+  Out,
+  ValidationParams = unknown
+> extends Validator<Out, ValidationParams> {}
+
+/**
+ * Validator for class instances (uses the `instanceof` operator)
+ *
+ * @export
+ * @class DefaultInstanceValidator
+ * @template Out
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<Out, ValidationParams>}
+ * @implements {InstanceValidator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultInstanceValidator<Out, ValidationParams = unknown>
+  extends DefaultValidator<Out, ValidationParams>
+  implements InstanceValidator<Out, ValidationParams>
+{
+  /**
+   * Creates an instance of DefaultInstanceValidator.
+   *
+   * @constructor
+   * @param {Constructor<Out>} _constructor the class/constructor to check against
+   */
+  constructor(private readonly _constructor: Constructor<Out>) {
+    super();
+  }
+
+  protected validateBaseType(
+    value_: unknown,
+    _params_?: ValidationParams
+  ): Out {
+    if (value_ instanceof this._constructor) {
+      return value_;
+    }
+
+    this.throwValidationError('value is not an instance of the expected type');
+  }
+}

--- a/src/validator/lazy.ts
+++ b/src/validator/lazy.ts
@@ -1,0 +1,55 @@
+import type { Validator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator that resolves its inner validator lazily (on validation), enabling
+ * recursive/self-referential schemas.
+ *
+ * @export
+ * @interface LazyValidator
+ * @template Out
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface LazyValidator<
+  Out,
+  ValidationParams = unknown
+> extends Validator<Out, ValidationParams> {}
+
+/**
+ * Validator that resolves its inner validator lazily (on validation), enabling
+ * recursive/self-referential schemas.
+ *
+ * @export
+ * @class DefaultLazyValidator
+ * @template Out
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<Out, ValidationParams>}
+ * @implements {LazyValidator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultLazyValidator<Out, ValidationParams = unknown>
+  extends DefaultValidator<Out, ValidationParams>
+  implements LazyValidator<Out, ValidationParams>
+{
+  /**
+   * Creates an instance of DefaultLazyValidator.
+   *
+   * @constructor
+   * @param {() => Validator<Out, ValidationParams>} _validatorFactory produces the actual validator on demand
+   */
+  constructor(
+    private readonly _validatorFactory: () => Validator<Out, ValidationParams>
+  ) {
+    super();
+  }
+
+  protected validateBaseType(value_: unknown, params_?: ValidationParams): Out {
+    try {
+      return this._validatorFactory().validate(value_, params_);
+    } catch (reason_) {
+      this.rethrowError(reason_, undefined, params_);
+    }
+  }
+}

--- a/src/validator/map.ts
+++ b/src/validator/map.ts
@@ -50,7 +50,7 @@ export class DefaultMapValidator<K, V, ValidationParams = unknown>
       this.throwValidationError('value is not a map');
     }
 
-    const map = value_ as Map<unknown, unknown>;
+    const map: Map<unknown, unknown> = value_;
     const errors: ValidationError[] = [];
 
     for (const [key, val] of map) {
@@ -72,10 +72,10 @@ export class DefaultMapValidator<K, V, ValidationParams = unknown>
   }
 
   private keyTrace(key_: unknown): PropertyKey | undefined {
-    const type = typeof key_;
-
-    return type === 'string' || type === 'number' || type === 'symbol'
-      ? (key_ as PropertyKey)
+    return typeof key_ === 'string' ||
+      typeof key_ === 'number' ||
+      typeof key_ === 'symbol'
+      ? key_
       : undefined;
   }
 }

--- a/src/validator/map.ts
+++ b/src/validator/map.ts
@@ -1,0 +1,98 @@
+import type { ValidationError } from '@/error.js';
+import type { NestedValidator, Validator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator for Map values. Each key and value has to match its validator.
+ *
+ * @export
+ * @interface MapValidator
+ * @template K
+ * @template V
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<Map<K, V>, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface MapValidator<
+  K,
+  V,
+  ValidationParams = unknown
+> extends Validator<Map<K, V>, ValidationParams> {}
+
+/**
+ * Validator for Map values. Each key and value has to match its validator.
+ *
+ * @export
+ * @class DefaultMapValidator
+ * @template K
+ * @template V
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<Map<K, V>, ValidationParams>}
+ * @implements {MapValidator<K, V, ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultMapValidator<K, V, ValidationParams = unknown>
+  extends DefaultValidator<Map<K, V>, ValidationParams>
+  implements MapValidator<K, V, ValidationParams>
+{
+  constructor(
+    private readonly _keyValidator: NestedValidator<K, ValidationParams>,
+    private readonly _valueValidator: NestedValidator<V, ValidationParams>
+  ) {
+    super();
+  }
+
+  protected validateBaseType(
+    value_: unknown,
+    params_?: ValidationParams
+  ): Map<K, V> {
+    if (!(value_ instanceof Map)) {
+      this.throwValidationError('value is not a map');
+    }
+
+    const map = value_ as Map<unknown, unknown>;
+    const errors: ValidationError[] = [];
+
+    for (const [key, val] of map) {
+      const trace = this.keyTrace(key);
+
+      try {
+        this.validateNested(key, this._keyValidator, params_);
+      } catch (reason_) {
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, trace));
+        } else {
+          this.rethrowError(reason_, trace);
+        }
+      }
+
+      try {
+        this.validateNested(val, this._valueValidator, params_);
+      } catch (reason_) {
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, trace));
+        } else {
+          this.rethrowError(reason_, trace);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more entries are invalid',
+        undefined,
+        errors
+      );
+    }
+
+    return value_ as Map<K, V>;
+  }
+
+  private keyTrace(key_: unknown): PropertyKey | undefined {
+    const type = typeof key_;
+
+    return type === 'string' || type === 'number' || type === 'symbol'
+      ? (key_ as PropertyKey)
+      : undefined;
+  }
+}

--- a/src/validator/map.ts
+++ b/src/validator/map.ts
@@ -1,6 +1,6 @@
 import type { ValidationError } from '@/error.js';
-import type { NestedValidator, Validator } from '@/types.js';
-import { DefaultValidator } from './index.js';
+import type { PropertyValidator, Validator } from '@/types.js';
+import { ContainerValidator } from './container.js';
 
 /**
  * Validator for Map values. Each key and value has to match its validator.
@@ -27,17 +27,17 @@ export interface MapValidator<
  * @template K
  * @template V
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Map<K, V>, ValidationParams>}
+ * @extends {ContainerValidator<Map<K, V>, ValidationParams>}
  * @implements {MapValidator<K, V, ValidationParams>}
  * @since 4.0.0
  */
 export class DefaultMapValidator<K, V, ValidationParams = unknown>
-  extends DefaultValidator<Map<K, V>, ValidationParams>
+  extends ContainerValidator<Map<K, V>, ValidationParams>
   implements MapValidator<K, V, ValidationParams>
 {
   constructor(
-    private readonly _keyValidator: NestedValidator<K, ValidationParams>,
-    private readonly _valueValidator: NestedValidator<V, ValidationParams>
+    private readonly _keyValidator: PropertyValidator<K, ValidationParams>,
+    private readonly _valueValidator: PropertyValidator<V, ValidationParams>
   ) {
     super();
   }
@@ -56,34 +56,17 @@ export class DefaultMapValidator<K, V, ValidationParams = unknown>
     for (const [key, val] of map) {
       const trace = this.keyTrace(key);
 
-      try {
-        this.validateNested(key, this._keyValidator, params_);
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, trace));
-        } else {
-          this.rethrowError(reason_, trace);
-        }
-      }
-
-      try {
-        this.validateNested(val, this._valueValidator, params_);
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, trace));
-        } else {
-          this.rethrowError(reason_, trace);
-        }
-      }
-    }
-
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more entries are invalid',
-        undefined,
-        errors
+      this.validateChild(errors, () => key, this._keyValidator, trace, params_);
+      this.validateChild(
+        errors,
+        () => val,
+        this._valueValidator,
+        trace,
+        params_
       );
     }
+
+    this.throwOnErrors(errors, 'one or more entries are invalid');
 
     return value_ as Map<K, V>;
   }

--- a/src/validator/nested.ts
+++ b/src/validator/nested.ts
@@ -1,4 +1,4 @@
-import type { Validator } from '@/types.js';
+import type { ValidationParamsMapper, Validator } from '@/types.js';
 
 const NESTED_VALIDATOR_MARKER = Symbol('NESTED_VALIDATOR_MARKER');
 
@@ -56,13 +56,14 @@ export class DefaultNestedValidator<
    *
    * @constructor
    * @param {Validator<Out, ChildValidationParams>} _validator the wrapped (nested) validator
-   * @param {(parentParams_: ParentValidationParams | undefined) => ChildValidationParams | undefined} _withParams maps the parent params to the wrapped validator's params
+   * @param {ValidationParamsMapper<ChildValidationParams, ParentValidationParams>} _withParams maps the parent params to the wrapped validator's params
    */
   constructor(
     private readonly _validator: Validator<Out, ChildValidationParams>,
-    private readonly _withParams: (
-      parentParams_: ParentValidationParams | undefined
-    ) => ChildValidationParams | undefined
+    private readonly _withParams: ValidationParamsMapper<
+      ChildValidationParams,
+      ParentValidationParams
+    >
   ) {}
 
   public validateNested(

--- a/src/validator/nested.ts
+++ b/src/validator/nested.ts
@@ -1,0 +1,92 @@
+import type { Validator } from '@/types.js';
+
+const NESTED_VALIDATOR_MARKER = Symbol('NESTED_VALIDATOR_MARKER');
+
+/**
+ * Descriptor produced by `ti.nested(...)`. It is NOT a standalone validator -
+ * it only lives inside a container's property/item validators and forwards
+ * (and maps) the parent's validation params to the wrapped validator.
+ *
+ * Being a distinct type (not a `Validator`) is what lets TypeScript infer the
+ * parent params type automatically from the surrounding validator.
+ *
+ * @export
+ * @interface NestedValidator
+ * @template Out
+ * @template [ParentValidationParams=unknown] params handed in by the parent validator
+ * @since 4.0.0
+ */
+export interface NestedValidator<Out, ParentValidationParams = unknown> {
+  readonly [NESTED_VALIDATOR_MARKER]: true;
+  /**
+   * validate a value with the wrapped validator, mapping the parent params to
+   * the wrapped validator's params
+   *
+   * @param {unknown} value_
+   * @param {ParentValidationParams | undefined} parentParams_
+   * @returns {Out}
+   */
+  validateNested(
+    value_: unknown,
+    parentParams_: ParentValidationParams | undefined
+  ): Out;
+}
+
+/**
+ * Default implementation of {@link NestedValidator}.
+ *
+ * @export
+ * @class DefaultNestedValidator
+ * @template Out
+ * @template [ParentValidationParams=unknown] params handed in by the parent validator
+ * @template [ChildValidationParams=unknown] params the wrapped validator expects
+ * @implements {NestedValidator<Out, ParentValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultNestedValidator<
+  Out,
+  ParentValidationParams = unknown,
+  ChildValidationParams = unknown
+> implements NestedValidator<Out, ParentValidationParams>
+{
+  public readonly [NESTED_VALIDATOR_MARKER] = true;
+
+  /**
+   * Creates an instance of DefaultNestedValidator.
+   *
+   * @constructor
+   * @param {Validator<Out, ChildValidationParams>} _validator the wrapped (nested) validator
+   * @param {(parentParams_: ParentValidationParams | undefined) => ChildValidationParams | undefined} _withParams maps the parent params to the wrapped validator's params
+   */
+  constructor(
+    private readonly _validator: Validator<Out, ChildValidationParams>,
+    private readonly _withParams: (
+      parentParams_: ParentValidationParams | undefined
+    ) => ChildValidationParams | undefined
+  ) {}
+
+  public validateNested(
+    value_: unknown,
+    parentParams_: ParentValidationParams | undefined
+  ): Out {
+    return this._validator.validate(value_, this._withParams(parentParams_));
+  }
+}
+
+/**
+ * determine whether a value is a {@link NestedValidator}
+ *
+ * @export
+ * @param {unknown} value_
+ * @returns {value_ is NestedValidator<unknown, unknown>}
+ * @since 4.0.0
+ */
+export function isNestedValidator(
+  value_: unknown
+): value_ is NestedValidator<unknown, unknown> {
+  return (
+    typeof value_ === 'object' &&
+    value_ !== null &&
+    NESTED_VALIDATOR_MARKER in value_
+  );
+}

--- a/src/validator/number.ts
+++ b/src/validator/number.ts
@@ -10,8 +10,10 @@ import { DefaultValidator } from './index.js';
  * @extends {Validator<number, ValidationParams>}
  * @since 1.0.0
  */
-export interface NumberValidator<ValidationParams = unknown>
-  extends Validator<number, ValidationParams> {
+export interface NumberValidator<ValidationParams = unknown> extends Validator<
+  number,
+  ValidationParams
+> {
   /**
    * accept positive values only (zero is not positive)
    *
@@ -92,6 +94,30 @@ export interface NumberValidator<ValidationParams = unknown>
    * @since 1.0.0
    */
   reject(...numbers_: ReadonlyArray<number>): this;
+  /**
+   * accept integers only
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get integer(): this;
+  /**
+   * accept safe integers only
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get safeInteger(): this;
+  /**
+   * accept numbers that are a multiple of the given base only
+   *
+   * @param {number} base_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  multipleOf(base_: number): this;
 }
 
 /**
@@ -150,6 +176,18 @@ export class DefaultNumberValidator<ValidationParams = unknown>
     return this.setupCondition((value_) =>
       this.checkRejected(value_, numbers_)
     );
+  }
+
+  public get integer(): this {
+    return this.setupCondition((value_) => this.checkInteger(value_));
+  }
+
+  public get safeInteger(): this {
+    return this.setupCondition((value_) => this.checkSafeInteger(value_));
+  }
+
+  public multipleOf(base_: number): this {
+    return this.setupCondition((value_) => this.checkMultipleOf(value_, base_));
   }
 
   protected validateBaseType(
@@ -226,6 +264,24 @@ export class DefaultNumberValidator<ValidationParams = unknown>
   ): void {
     if (rejected_.includes(value_)) {
       this.throwValidationError('number is rejected');
+    }
+  }
+
+  private checkInteger(value_: number): void {
+    if (!Number.isInteger(value_)) {
+      this.throwValidationError('number is not an integer');
+    }
+  }
+
+  private checkSafeInteger(value_: number): void {
+    if (!Number.isSafeInteger(value_)) {
+      this.throwValidationError('number is not a safe integer');
+    }
+  }
+
+  private checkMultipleOf(value_: number, base_: number): void {
+    if (base_ === 0 || value_ % base_ !== 0) {
+      this.throwValidationError('number is not a multiple of the given base');
     }
   }
 }

--- a/src/validator/object.ts
+++ b/src/validator/object.ts
@@ -1,8 +1,12 @@
 import type { ValidationError } from '@/error.js';
-import type { PropertyValidators, Validator } from '@/types.js';
+import type {
+  PropertyValidator,
+  PropertyValidators,
+  Validator
+} from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
-import { DefaultValidator } from './index.js';
+import { PropertiesValidator } from './properties.js';
 
 /**
  * Validator for object based values. Each property has to match its specified validator
@@ -27,6 +31,32 @@ export interface ObjectValidator<
    * @since 1.0.0
    */
   get noOverload(): this;
+  /**
+   * Reject array values (arrays are objects too and pass by default)
+   *
+   * @readonly
+   * @type {this}
+   * @since 4.0.0
+   */
+  get rejectArray(): this;
+  /**
+   * Retrieve the validator defined for a specific property.
+   *
+   * @template {keyof Out} Key
+   * @param {Key} key_
+   * @returns {PropertyValidator<Out[Key], ValidationParams>}
+   * @since 4.0.0
+   */
+  prop<Key extends keyof Out>(
+    key_: Key
+  ): PropertyValidator<Out[Key], ValidationParams>;
+  /**
+   * Retrieve the validators defined for all properties.
+   *
+   * @returns {PropertyValidators<Out, ValidationParams>}
+   * @since 4.0.0
+   */
+  props(): PropertyValidators<Out, ValidationParams>;
 }
 
 /**
@@ -36,28 +66,27 @@ export interface ObjectValidator<
  * @class DefaultObjectValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Out, ValidationParams>}
+ * @extends {PropertiesValidator<Out, ValidationParams, PropertyValidators<Out, ValidationParams>>}
  * @implements {ObjectValidator<Out, ValidationParams>}
  * @since 1.0.0
  */
 export class DefaultObjectValidator<
-  Out extends RecordLike,
-  ValidationParams = unknown
->
-  extends DefaultValidator<Out, ValidationParams>
+    Out extends RecordLike,
+    ValidationParams = unknown
+  >
+  extends PropertiesValidator<
+    Out,
+    ValidationParams,
+    PropertyValidators<Out, ValidationParams>
+  >
   implements ObjectValidator<Out, ValidationParams>
 {
-  constructor(
-    private readonly _propertyValidators: PropertyValidators<
-      Out,
-      ValidationParams
-    >
-  ) {
-    super();
-  }
-
   public get noOverload(): this {
     return this.setupCondition((value_) => this.checkOverload(value_));
+  }
+
+  public get rejectArray(): this {
+    return this.setupCondition((value_) => this.checkArray(value_));
   }
 
   protected validateBaseType(value_: unknown, params_?: ValidationParams): Out {
@@ -69,28 +98,16 @@ export class DefaultObjectValidator<
 
     // keep optional parameters in mind! The value must be validated even if it is undefined
     for (const validatorKey in this._propertyValidators) {
-      try {
-        this.validateNested(
-          value_[validatorKey],
-          this._propertyValidators[validatorKey],
-          params_
-        );
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, validatorKey));
-        } else {
-          this.rethrowError(reason_, validatorKey);
-        }
-      }
-    }
-
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more properties are invalid',
-        undefined,
-        errors
+      this.validateChild(
+        errors,
+        () => value_[validatorKey],
+        this._propertyValidators[validatorKey],
+        validatorKey,
+        params_
       );
     }
+
+    this.throwOnErrors(errors, 'one or more properties are invalid');
 
     return value_;
   }
@@ -100,6 +117,12 @@ export class DefaultObjectValidator<
       if (!(propertyKey in this._propertyValidators)) {
         this.throwValidationError('value is overloaded');
       }
+    }
+  }
+
+  private checkArray(value_: RecordLike): void {
+    if (Array.isArray(value_)) {
+      this.throwValidationError('value must not be an array');
     }
   }
 }

--- a/src/validator/object.ts
+++ b/src/validator/object.ts
@@ -1,9 +1,5 @@
 import type { ValidationError } from '@/error.js';
-import type {
-  PropertyValidator,
-  PropertyValidators,
-  Validator
-} from '@/types.js';
+import type { PropertyValidators, Validator } from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
 import { PropertiesValidator } from './properties.js';
@@ -15,12 +11,17 @@ import { PropertiesValidator } from './properties.js';
  * @interface ObjectValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
+ * @template {PropertyValidators<Out, ValidationParams>} [PV=PropertyValidators<Out, ValidationParams>] the concrete property validators map
  * @extends {Validator<Out, ValidationParams>}
  * @since 1.0.0
  */
 export interface ObjectValidator<
   Out extends RecordLike,
-  ValidationParams = unknown
+  ValidationParams = unknown,
+  PV extends PropertyValidators<Out, ValidationParams> = PropertyValidators<
+    Out,
+    ValidationParams
+  >
 > extends Validator<Out, ValidationParams> {
   /**
    * Reject objects that contain more keys than have been validated
@@ -42,21 +43,19 @@ export interface ObjectValidator<
   /**
    * Retrieve the validator defined for a specific property.
    *
-   * @template {keyof Out} Key
+   * @template {keyof PV} Key
    * @param {Key} key_
-   * @returns {PropertyValidator<Out[Key], ValidationParams>}
+   * @returns {PV[Key]}
    * @since 4.0.0
    */
-  prop<Key extends keyof Out>(
-    key_: Key
-  ): PropertyValidator<Out[Key], ValidationParams>;
+  prop<Key extends keyof PV>(key_: Key): PV[Key];
   /**
    * Retrieve the validators defined for all properties.
    *
-   * @returns {PropertyValidators<Out, ValidationParams>}
+   * @returns {PV}
    * @since 4.0.0
    */
-  props(): PropertyValidators<Out, ValidationParams>;
+  props(): PV;
 }
 
 /**
@@ -66,20 +65,21 @@ export interface ObjectValidator<
  * @class DefaultObjectValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {PropertiesValidator<Out, ValidationParams, PropertyValidators<Out, ValidationParams>>}
+ * @template {PropertyValidators<Out, ValidationParams>} [PV=PropertyValidators<Out, ValidationParams>] the concrete property validators map (lets `prop`/`props` return the exact validator types)
+ * @extends {PropertiesValidator<Out, ValidationParams, PV>}
  * @implements {ObjectValidator<Out, ValidationParams>}
  * @since 1.0.0
  */
 export class DefaultObjectValidator<
     Out extends RecordLike,
-    ValidationParams = unknown
+    ValidationParams = unknown,
+    PV extends PropertyValidators<Out, ValidationParams> = PropertyValidators<
+      Out,
+      ValidationParams
+    >
   >
-  extends PropertiesValidator<
-    Out,
-    ValidationParams,
-    PropertyValidators<Out, ValidationParams>
-  >
-  implements ObjectValidator<Out, ValidationParams>
+  extends PropertiesValidator<Out, ValidationParams, PV>
+  implements ObjectValidator<Out, ValidationParams, PV>
 {
   public get noOverload(): this {
     return this.setupCondition((value_) => this.checkOverload(value_));

--- a/src/validator/object.ts
+++ b/src/validator/object.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from '@/error.js';
 import type { PropertyValidators, Validator } from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
@@ -40,9 +41,9 @@ export interface ObjectValidator<
  * @since 1.0.0
  */
 export class DefaultObjectValidator<
-    Out extends RecordLike,
-    ValidationParams = unknown
-  >
+  Out extends RecordLike,
+  ValidationParams = unknown
+>
   extends DefaultValidator<Out, ValidationParams>
   implements ObjectValidator<Out, ValidationParams>
 {
@@ -64,6 +65,8 @@ export class DefaultObjectValidator<
       this.throwValidationError('value is not an object');
     }
 
+    const errors: ValidationError[] = [];
+
     // keep optional parameters in mind! The value must be validated even if it is undefined
     for (const validatorKey in this._propertyValidators) {
       try {
@@ -73,8 +76,20 @@ export class DefaultObjectValidator<
           params_
         );
       } catch (reason_) {
-        this.rethrowError(reason_, validatorKey);
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, validatorKey));
+        } else {
+          this.rethrowError(reason_, validatorKey);
+        }
       }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more properties are invalid',
+        undefined,
+        errors
+      );
     }
 
     return value_;

--- a/src/validator/partial.ts
+++ b/src/validator/partial.ts
@@ -1,9 +1,5 @@
 import type { ValidationError } from '@/error.js';
-import type {
-  PartialPropertyValidators,
-  PropertyValidator,
-  Validator
-} from '@/types.js';
+import type { PartialPropertyValidators, Validator } from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
 import { PropertiesValidator } from './properties.js';
@@ -15,31 +11,34 @@ import { PropertiesValidator } from './properties.js';
  * @interface PartialValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
+ * @template {PartialPropertyValidators<Out, ValidationParams>} [PV=PartialPropertyValidators<Out, ValidationParams>] the concrete property validators map
  * @extends {Validator<Out, ValidationParams>}
  * @since 2.0.0
  */
 export interface PartialValidator<
   Out extends RecordLike,
-  ValidationParams = unknown
+  ValidationParams = unknown,
+  PV extends PartialPropertyValidators<
+    Out,
+    ValidationParams
+  > = PartialPropertyValidators<Out, ValidationParams>
 > extends Validator<Out, ValidationParams> {
   /**
    * Retrieve the validator defined for a specific property (may be undefined).
    *
-   * @template {keyof Out} Key
+   * @template {keyof PV} Key
    * @param {Key} key_
-   * @returns {PropertyValidator<Out[Key], ValidationParams> | undefined}
+   * @returns {PV[Key]}
    * @since 4.0.0
    */
-  prop<Key extends keyof Out>(
-    key_: Key
-  ): PropertyValidator<Out[Key], ValidationParams> | undefined;
+  prop<Key extends keyof PV>(key_: Key): PV[Key];
   /**
    * Retrieve the validators defined for all (specified) properties.
    *
-   * @returns {PartialPropertyValidators<Out, ValidationParams>}
+   * @returns {PV}
    * @since 4.0.0
    */
-  props(): PartialPropertyValidators<Out, ValidationParams>;
+  props(): PV;
 }
 
 /**
@@ -49,20 +48,21 @@ export interface PartialValidator<
  * @class DefaultPartialValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {PropertiesValidator<Out, ValidationParams, PartialPropertyValidators<Out, ValidationParams>>}
+ * @template {PartialPropertyValidators<Out, ValidationParams>} [PV=PartialPropertyValidators<Out, ValidationParams>] the concrete property validators map (lets `prop`/`props` return the exact validator types)
+ * @extends {PropertiesValidator<Out, ValidationParams, PV>}
  * @implements {PartialValidator<Out, ValidationParams>}
  * @since 2.0.0
  */
 export class DefaultPartialValidator<
     Out extends RecordLike,
-    ValidationParams = unknown
+    ValidationParams = unknown,
+    PV extends PartialPropertyValidators<
+      Out,
+      ValidationParams
+    > = PartialPropertyValidators<Out, ValidationParams>
   >
-  extends PropertiesValidator<
-    Out,
-    ValidationParams,
-    PartialPropertyValidators<Out, ValidationParams>
-  >
-  implements PartialValidator<Out, ValidationParams>
+  extends PropertiesValidator<Out, ValidationParams, PV>
+  implements PartialValidator<Out, ValidationParams, PV>
 {
 
   protected validateBaseType(value_: unknown, params_?: ValidationParams): Out {

--- a/src/validator/partial.ts
+++ b/src/validator/partial.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from '@/error.js';
 import type { PartialPropertyValidators, Validator } from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
@@ -30,9 +31,9 @@ export interface PartialValidator<
  * @since 2.0.0
  */
 export class DefaultPartialValidator<
-    Out extends RecordLike,
-    ValidationParams = unknown
-  >
+  Out extends RecordLike,
+  ValidationParams = unknown
+>
   extends DefaultValidator<Out, ValidationParams>
   implements PartialValidator<Out, ValidationParams>
 {
@@ -50,6 +51,8 @@ export class DefaultPartialValidator<
       this.throwValidationError('value is not an object');
     }
 
+    const errors: ValidationError[] = [];
+
     for (const validatorKey in this._propertyValidators) {
       try {
         const propertyValidator = this._propertyValidators[validatorKey];
@@ -58,8 +61,20 @@ export class DefaultPartialValidator<
           this.validateNested(value_[validatorKey], propertyValidator, params_);
         }
       } catch (reason_) {
-        this.rethrowError(reason_, validatorKey);
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, validatorKey));
+        } else {
+          this.rethrowError(reason_, validatorKey);
+        }
       }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more properties are invalid',
+        undefined,
+        errors
+      );
     }
 
     return value_;

--- a/src/validator/partial.ts
+++ b/src/validator/partial.ts
@@ -1,8 +1,12 @@
 import type { ValidationError } from '@/error.js';
-import type { PartialPropertyValidators, Validator } from '@/types.js';
+import type {
+  PartialPropertyValidators,
+  PropertyValidator,
+  Validator
+} from '@/types.js';
 import { isObject } from '@/utils.js';
 import type { RecordLike } from 'ts-lib-extended';
-import { DefaultValidator } from './index.js';
+import { PropertiesValidator } from './properties.js';
 
 /**
  * Validator for object based values. This is an **UNSAFE** validator that only validates some properties and ignores others
@@ -17,7 +21,26 @@ import { DefaultValidator } from './index.js';
 export interface PartialValidator<
   Out extends RecordLike,
   ValidationParams = unknown
-> extends Validator<Out, ValidationParams> {}
+> extends Validator<Out, ValidationParams> {
+  /**
+   * Retrieve the validator defined for a specific property (may be undefined).
+   *
+   * @template {keyof Out} Key
+   * @param {Key} key_
+   * @returns {PropertyValidator<Out[Key], ValidationParams> | undefined}
+   * @since 4.0.0
+   */
+  prop<Key extends keyof Out>(
+    key_: Key
+  ): PropertyValidator<Out[Key], ValidationParams> | undefined;
+  /**
+   * Retrieve the validators defined for all (specified) properties.
+   *
+   * @returns {PartialPropertyValidators<Out, ValidationParams>}
+   * @since 4.0.0
+   */
+  props(): PartialPropertyValidators<Out, ValidationParams>;
+}
 
 /**
  * Validator for object based values. This is an **UNSAFE** validator that only validates some properties and ignores others
@@ -26,25 +49,21 @@ export interface PartialValidator<
  * @class DefaultPartialValidator
  * @template {RecordLike} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Out, ValidationParams>}
+ * @extends {PropertiesValidator<Out, ValidationParams, PartialPropertyValidators<Out, ValidationParams>>}
  * @implements {PartialValidator<Out, ValidationParams>}
  * @since 2.0.0
  */
 export class DefaultPartialValidator<
-  Out extends RecordLike,
-  ValidationParams = unknown
->
-  extends DefaultValidator<Out, ValidationParams>
+    Out extends RecordLike,
+    ValidationParams = unknown
+  >
+  extends PropertiesValidator<
+    Out,
+    ValidationParams,
+    PartialPropertyValidators<Out, ValidationParams>
+  >
   implements PartialValidator<Out, ValidationParams>
 {
-  constructor(
-    private readonly _propertyValidators: PartialPropertyValidators<
-      Out,
-      ValidationParams
-    >
-  ) {
-    super();
-  }
 
   protected validateBaseType(value_: unknown, params_?: ValidationParams): Out {
     if (!isObject(value_)) {
@@ -54,28 +73,20 @@ export class DefaultPartialValidator<
     const errors: ValidationError[] = [];
 
     for (const validatorKey in this._propertyValidators) {
-      try {
-        const propertyValidator = this._propertyValidators[validatorKey];
+      const propertyValidator = this._propertyValidators[validatorKey];
 
-        if (propertyValidator) {
-          this.validateNested(value_[validatorKey], propertyValidator, params_);
-        }
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, validatorKey));
-        } else {
-          this.rethrowError(reason_, validatorKey);
-        }
+      if (propertyValidator) {
+        this.validateChild(
+          errors,
+          () => value_[validatorKey],
+          propertyValidator,
+          validatorKey,
+          params_
+        );
       }
     }
 
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more properties are invalid',
-        undefined,
-        errors
-      );
-    }
+    this.throwOnErrors(errors, 'one or more properties are invalid');
 
     return value_;
   }

--- a/src/validator/properties.ts
+++ b/src/validator/properties.ts
@@ -1,0 +1,55 @@
+import type { PartialPropertyValidators } from '@/types.js';
+import type { RecordLike } from 'ts-lib-extended';
+import { ContainerValidator } from './container.js';
+
+/**
+ * Base class for validators built from a map of per-property validators
+ * (object, partial). Stores the property validators and exposes them via
+ * {@link prop} / {@link props}.
+ *
+ * @export
+ * @abstract
+ * @class PropertiesValidator
+ * @template {RecordLike} Out
+ * @template ValidationParams extended validation parameters
+ * @template {PartialPropertyValidators<Out, ValidationParams>} PV the concrete property validators map
+ * @extends {ContainerValidator<Out, ValidationParams>}
+ * @since 4.0.0
+ */
+export abstract class PropertiesValidator<
+  Out extends RecordLike,
+  ValidationParams,
+  PV extends PartialPropertyValidators<Out, ValidationParams>
+> extends ContainerValidator<Out, ValidationParams> {
+  /**
+   * Creates an instance of PropertiesValidator.
+   *
+   * @constructor
+   * @param {PV} _propertyValidators the validators for each property
+   */
+  constructor(protected readonly _propertyValidators: PV) {
+    super();
+  }
+
+  /**
+   * Retrieve the validator defined for a specific property.
+   *
+   * @template {keyof PV} Key
+   * @param {Key} key_
+   * @returns {PV[Key]}
+   * @since 4.0.0
+   */
+  public prop<Key extends keyof PV>(key_: Key): PV[Key] {
+    return this._propertyValidators[key_];
+  }
+
+  /**
+   * Retrieve the validators defined for all properties.
+   *
+   * @returns {PV}
+   * @since 4.0.0
+   */
+  public props(): PV {
+    return this._propertyValidators;
+  }
+}

--- a/src/validator/set.ts
+++ b/src/validator/set.ts
@@ -46,7 +46,7 @@ export class DefaultSetValidator<V, ValidationParams = unknown>
       this.throwValidationError('value is not a set');
     }
 
-    const set = value_ as Set<unknown>;
+    const set: Set<unknown> = value_;
     const errors: ValidationError[] = [];
     let index = 0;
 

--- a/src/validator/set.ts
+++ b/src/validator/set.ts
@@ -1,6 +1,6 @@
 import type { ValidationError } from '@/error.js';
-import type { NestedValidator, Validator } from '@/types.js';
-import { DefaultValidator } from './index.js';
+import type { PropertyValidator, Validator } from '@/types.js';
+import { ContainerValidator } from './container.js';
 
 /**
  * Validator for Set values. Each item has to match the item validator.
@@ -24,16 +24,16 @@ export interface SetValidator<V, ValidationParams = unknown> extends Validator<
  * @class DefaultSetValidator
  * @template V
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Set<V>, ValidationParams>}
+ * @extends {ContainerValidator<Set<V>, ValidationParams>}
  * @implements {SetValidator<V, ValidationParams>}
  * @since 4.0.0
  */
 export class DefaultSetValidator<V, ValidationParams = unknown>
-  extends DefaultValidator<Set<V>, ValidationParams>
+  extends ContainerValidator<Set<V>, ValidationParams>
   implements SetValidator<V, ValidationParams>
 {
   constructor(
-    private readonly _itemValidator: NestedValidator<V, ValidationParams>
+    private readonly _itemValidator: PropertyValidator<V, ValidationParams>
   ) {
     super();
   }
@@ -51,26 +51,11 @@ export class DefaultSetValidator<V, ValidationParams = unknown>
     let index = 0;
 
     for (const item of set) {
-      try {
-        this.validateNested(item, this._itemValidator, params_);
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, index));
-        } else {
-          this.rethrowError(reason_, index);
-        }
-      }
-
+      this.validateChild(errors, () => item, this._itemValidator, index, params_);
       index++;
     }
 
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more items are invalid',
-        undefined,
-        errors
-      );
-    }
+    this.throwOnErrors(errors, 'one or more items are invalid');
 
     return value_ as Set<V>;
   }

--- a/src/validator/set.ts
+++ b/src/validator/set.ts
@@ -1,0 +1,77 @@
+import type { ValidationError } from '@/error.js';
+import type { NestedValidator, Validator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator for Set values. Each item has to match the item validator.
+ *
+ * @export
+ * @interface SetValidator
+ * @template V
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<Set<V>, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface SetValidator<V, ValidationParams = unknown> extends Validator<
+  Set<V>,
+  ValidationParams
+> {}
+
+/**
+ * Validator for Set values. Each item has to match the item validator.
+ *
+ * @export
+ * @class DefaultSetValidator
+ * @template V
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<Set<V>, ValidationParams>}
+ * @implements {SetValidator<V, ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultSetValidator<V, ValidationParams = unknown>
+  extends DefaultValidator<Set<V>, ValidationParams>
+  implements SetValidator<V, ValidationParams>
+{
+  constructor(
+    private readonly _itemValidator: NestedValidator<V, ValidationParams>
+  ) {
+    super();
+  }
+
+  protected validateBaseType(
+    value_: unknown,
+    params_?: ValidationParams
+  ): Set<V> {
+    if (!(value_ instanceof Set)) {
+      this.throwValidationError('value is not a set');
+    }
+
+    const set = value_ as Set<unknown>;
+    const errors: ValidationError[] = [];
+    let index = 0;
+
+    for (const item of set) {
+      try {
+        this.validateNested(item, this._itemValidator, params_);
+      } catch (reason_) {
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, index));
+        } else {
+          this.rethrowError(reason_, index);
+        }
+      }
+
+      index++;
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more items are invalid',
+        undefined,
+        errors
+      );
+    }
+
+    return value_ as Set<V>;
+  }
+}

--- a/src/validator/string.ts
+++ b/src/validator/string.ts
@@ -12,8 +12,10 @@ import { DefaultValidator } from './index.js';
  * @extends {Validator<string, ValidationParams>}
  * @since 1.0.0
  */
-export interface StringValidator<ValidationParams = unknown>
-  extends Validator<string, ValidationParams> {
+export interface StringValidator<ValidationParams = unknown> extends Validator<
+  string,
+  ValidationParams
+> {
   /**
    * define minimum string length
    *
@@ -135,6 +137,30 @@ export interface StringValidator<ValidationParams = unknown>
    * @since 1.0.0
    */
   get hex(): this;
+  /**
+   * string has to start with the given substring
+   *
+   * @param {string} prefix_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  startsWith(prefix_: string): this;
+  /**
+   * string has to end with the given substring
+   *
+   * @param {string} suffix_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  endsWith(suffix_: string): this;
+  /**
+   * string has to contain the given substring
+   *
+   * @param {string} substring_
+   * @returns {this}
+   * @since 4.0.0
+   */
+  includes(substring_: string): this;
 }
 
 /**
@@ -213,6 +239,22 @@ export class DefaultStringValidator<ValidationParams = unknown>
 
   public get hex(): this {
     return this.setupCondition((value_) => this.checkHex(value_));
+  }
+
+  public startsWith(prefix_: string): this {
+    return this.setupCondition((value_) =>
+      this.checkStartsWith(value_, prefix_)
+    );
+  }
+
+  public endsWith(suffix_: string): this {
+    return this.setupCondition((value_) => this.checkEndsWith(value_, suffix_));
+  }
+
+  public includes(substring_: string): this {
+    return this.setupCondition((value_) =>
+      this.checkIncludes(value_, substring_)
+    );
   }
 
   protected validateBaseType(
@@ -333,6 +375,24 @@ export class DefaultStringValidator<ValidationParams = unknown>
   private checkHex(value_: string): void {
     if (!/^[0-9a-fA-F]+$/.test(value_)) {
       this.throwValidationError('string is not a hexadecimal value');
+    }
+  }
+
+  private checkStartsWith(value_: string, prefix_: string): void {
+    if (!value_.startsWith(prefix_)) {
+      this.throwValidationError('string does not start with the given value');
+    }
+  }
+
+  private checkEndsWith(value_: string, suffix_: string): void {
+    if (!value_.endsWith(suffix_)) {
+      this.throwValidationError('string does not end with the given value');
+    }
+  }
+
+  private checkIncludes(value_: string, substring_: string): void {
+    if (!value_.includes(substring_)) {
+      this.throwValidationError('string does not contain the given value');
     }
   }
 

--- a/src/validator/symbol.ts
+++ b/src/validator/symbol.ts
@@ -1,0 +1,42 @@
+import type { Validator } from '@/types.js';
+import { DefaultValidator } from './index.js';
+
+/**
+ * Validator for symbol values
+ *
+ * @export
+ * @interface SymbolValidator
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {Validator<symbol, ValidationParams>}
+ * @since 4.0.0
+ */
+export interface SymbolValidator<ValidationParams = unknown> extends Validator<
+  symbol,
+  ValidationParams
+> {}
+
+/**
+ * Validator for symbol values
+ *
+ * @export
+ * @class DefaultSymbolValidator
+ * @template [ValidationParams=unknown] extended validation parameters
+ * @extends {DefaultValidator<symbol, ValidationParams>}
+ * @implements {SymbolValidator<ValidationParams>}
+ * @since 4.0.0
+ */
+export class DefaultSymbolValidator<ValidationParams = unknown>
+  extends DefaultValidator<symbol, ValidationParams>
+  implements SymbolValidator<ValidationParams>
+{
+  protected validateBaseType(
+    value_: unknown,
+    _params_?: ValidationParams
+  ): symbol {
+    if (typeof value_ === 'symbol') {
+      return value_;
+    }
+
+    this.throwValidationError('value is not a symbol');
+  }
+}

--- a/src/validator/tuple.ts
+++ b/src/validator/tuple.ts
@@ -1,6 +1,6 @@
 import type { ValidationError } from '@/error.js';
 import type { TupleItemValidators, Validator } from '@/types.js';
-import { DefaultValidator } from './index.js';
+import { ContainerValidator } from './container.js';
 
 /**
  * Validator for tuple based values. Each item has to match its specified validator
@@ -33,7 +33,7 @@ export interface TupleValidator<
  * @class DefaultTupleValidator
  * @template {unknown[]} Out
  * @template [ValidationParams=unknown] extended validation parameters
- * @extends {DefaultValidator<Out, ValidationParams>}
+ * @extends {ContainerValidator<Out, ValidationParams>}
  * @implements {TupleValidator<Out, ValidationParams>}
  * @since 3.0.0
  */
@@ -41,7 +41,7 @@ export class DefaultTupleValidator<
   Out extends unknown[],
   ValidationParams = unknown
 >
-  extends DefaultValidator<Out, ValidationParams>
+  extends ContainerValidator<Out, ValidationParams>
   implements TupleValidator<Out, ValidationParams>
 {
   private readonly _itemValidators: TupleItemValidators<Out, ValidationParams>;
@@ -67,24 +67,16 @@ export class DefaultTupleValidator<
     const errors: ValidationError[] = [];
 
     for (let i = 0; i < this._itemValidators.length; i++) {
-      try {
-        this.validateNested(value_[i], this._itemValidators[i], params_);
-      } catch (reason_) {
-        if (this.aggregatesErrors) {
-          errors.push(this.collectNestedError(reason_, i));
-        } else {
-          this.rethrowError(reason_, i);
-        }
-      }
-    }
-
-    if (errors.length > 0) {
-      this.throwValidationError(
-        'one or more items are invalid',
-        undefined,
-        errors
+      this.validateChild(
+        errors,
+        () => value_[i],
+        this._itemValidators[i],
+        i,
+        params_
       );
     }
+
+    this.throwOnErrors(errors, 'one or more items are invalid');
 
     return value_ as Out;
   }

--- a/src/validator/tuple.ts
+++ b/src/validator/tuple.ts
@@ -38,7 +38,7 @@ export interface TupleValidator<
  * @since 3.0.0
  */
 export class DefaultTupleValidator<
-  Out extends unknown[],
+  const Out extends unknown[],
   ValidationParams = unknown
 >
   extends ContainerValidator<Out, ValidationParams>

--- a/src/validator/tuple.ts
+++ b/src/validator/tuple.ts
@@ -46,7 +46,7 @@ export class DefaultTupleValidator<
 {
   private readonly _itemValidators: TupleItemValidators<Out, ValidationParams>;
 
-  constructor(...itemValidators_: TupleItemValidators<Out, ValidationParams>) {
+  constructor(itemValidators_: TupleItemValidators<Out, ValidationParams>) {
     super();
     this._itemValidators = itemValidators_;
   }

--- a/src/validator/tuple.ts
+++ b/src/validator/tuple.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from '@/error.js';
 import type { TupleItemValidators, Validator } from '@/types.js';
 import { DefaultValidator } from './index.js';
 
@@ -37,9 +38,9 @@ export interface TupleValidator<
  * @since 3.0.0
  */
 export class DefaultTupleValidator<
-    Out extends unknown[],
-    ValidationParams = unknown
-  >
+  Out extends unknown[],
+  ValidationParams = unknown
+>
   extends DefaultValidator<Out, ValidationParams>
   implements TupleValidator<Out, ValidationParams>
 {
@@ -63,12 +64,26 @@ export class DefaultTupleValidator<
       this.throwValidationError('too few items');
     }
 
+    const errors: ValidationError[] = [];
+
     for (let i = 0; i < this._itemValidators.length; i++) {
       try {
         this.validateNested(value_[i], this._itemValidators[i], params_);
       } catch (reason_) {
-        this.rethrowError(reason_, i);
+        if (this.aggregatesErrors) {
+          errors.push(this.collectNestedError(reason_, i));
+        } else {
+          this.rethrowError(reason_, i);
+        }
       }
+    }
+
+    if (errors.length > 0) {
+      this.throwValidationError(
+        'one or more items are invalid',
+        undefined,
+        errors
+      );
     }
 
     return value_ as Out;

--- a/src/validator/undefined.ts
+++ b/src/validator/undefined.ts
@@ -10,8 +10,9 @@ import { DefaultValidator } from './index.js';
  * @extends {Validator<undefined, ValidationParams>}
  * @since 1.0.0
  */
-export interface UndefinedValidator<ValidationParams = unknown>
-  extends Validator<undefined, ValidationParams> {}
+export interface UndefinedValidator<
+  ValidationParams = unknown
+> extends Validator<undefined, ValidationParams> {}
 
 /**
  * Validator for undefined values
@@ -38,22 +39,3 @@ export class DefaultUndefinedValidator<ValidationParams = unknown>
     this.throwValidationError('value is defined');
   }
 }
-
-/**
- * Validator for undefined values
- *
- * @export
- * @deprecated misspelled name - use {@link DefaultUndefinedValidator} instead
- * @since 1.0.0
- */
-export const DefaulUndefinedValidator = DefaultUndefinedValidator;
-
-/**
- * Validator for undefined values
- *
- * @export
- * @deprecated misspelled name - use {@link DefaultUndefinedValidator} instead
- * @since 1.0.0
- */
-export type DefaulUndefinedValidator<ValidationParams = unknown> =
-  DefaultUndefinedValidator<ValidationParams>;

--- a/tests/code/aggregate.test.ts
+++ b/tests/code/aggregate.test.ts
@@ -1,8 +1,15 @@
 import { flattenValidationError } from '@/error.js';
+import { DefaultValidator } from '@/index.js';
 import { TypeInspector } from '@/inspector.js';
 import { describe, expect, test } from 'vitest';
 
 const ti = new TypeInspector();
+
+class RawThrowValidator extends DefaultValidator<string> {
+  protected validateBaseType(): string {
+    throw new Error('raw boom');
+  }
+}
 
 describe('aggregate (collect-all) mode', () => {
   test('object collects all invalid properties', () => {
@@ -77,6 +84,15 @@ describe('aggregate (collect-all) mode', () => {
   test('aggregate is a no-op on valid input', () => {
     expect.assertions(1);
     expect(ti.array(ti.number).aggregate.isValid([1, 2, 3])).toBe(true);
+  });
+
+  test('aggregate preserves a non-ValidationError message', () => {
+    expect.assertions(2);
+    const validator = ti.object({ a: new RawThrowValidator() }).aggregate;
+    expect(validator.isValid({ a: 'x' })).toBe(false);
+    expect(validator.validationError?.subErrors?.[0]?.message).toContain(
+      'raw boom'
+    );
   });
 });
 

--- a/tests/code/aggregate.test.ts
+++ b/tests/code/aggregate.test.ts
@@ -1,0 +1,101 @@
+import { flattenValidationError } from '@/error.js';
+import { TypeInspector } from '@/inspector.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe('aggregate (collect-all) mode', () => {
+  test('object collects all invalid properties', () => {
+    expect.assertions(3);
+    const validator = ti.object({
+      a: ti.string,
+      b: ti.number,
+      c: ti.boolean
+    }).aggregate;
+    // a + b invalid, c valid
+    expect(validator.isValid({ a: 1, b: 'x', c: true })).toBe(false);
+    const error = validator.validationError;
+    expect(error?.subErrors?.length).toBe(2);
+    expect(
+      flattenValidationError(error!)
+        .map((entry) => entry.path)
+        .sort()
+    ).toEqual(['a', 'b']);
+  });
+
+  test('partial collects all invalid properties', () => {
+    expect.assertions(2);
+    const validator = ti.partial({ a: ti.string, b: ti.number }).aggregate;
+    expect(validator.isValid({ a: 1, b: 'x' })).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('array collects all invalid items', () => {
+    expect.assertions(3);
+    const validator = ti.array(ti.number).aggregate;
+    expect(validator.isValid([1, 'x', 'y'])).toBe(false);
+    const error = validator.validationError;
+    expect(error?.subErrors?.length).toBe(2);
+    expect(flattenValidationError(error!).map((e) => e.path)).toEqual(['1', '2']);
+  });
+
+  test('tuple collects all invalid items', () => {
+    expect.assertions(2);
+    const validator = ti.tuple(ti.string, ti.number).aggregate;
+    expect(validator.isValid([1, 'x'])).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('dictionary collects all invalid values', () => {
+    expect.assertions(2);
+    const validator = ti.dictionary(ti.number).aggregate;
+    expect(validator.isValid({ a: 'x', b: 'y' })).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('map collects all invalid entries', () => {
+    expect.assertions(2);
+    const validator = ti.map(ti.string, ti.number).aggregate;
+    expect(
+      validator.isValid(
+        new Map([
+          ['a', 'x'],
+          ['b', 'y']
+        ])
+      )
+    ).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('set collects all invalid items', () => {
+    expect.assertions(2);
+    const validator = ti.set(ti.number).aggregate;
+    expect(validator.isValid(new Set<unknown>(['x', 'y']))).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('aggregate is a no-op on valid input', () => {
+    expect.assertions(1);
+    expect(ti.array(ti.number).aggregate.isValid([1, 2, 3])).toBe(true);
+  });
+});
+
+describe(flattenValidationError, () => {
+  test('single leaf error -> one entry without path', () => {
+    expect.assertions(1);
+    const validator = ti.string;
+    validator.isValid(42);
+    expect(flattenValidationError(validator.validationError!)).toEqual([
+      { path: undefined, message: 'value is not a string' }
+    ]);
+  });
+
+  test('nested single error -> one entry with full path', () => {
+    expect.assertions(1);
+    const validator = ti.object({ a: ti.object({ b: ti.string }) });
+    validator.isValid({ a: { b: 1 } });
+    expect(flattenValidationError(validator.validationError!)).toEqual([
+      { path: 'a.b', message: 'value is not a string' }
+    ]);
+  });
+});

--- a/tests/code/complex.test.ts
+++ b/tests/code/complex.test.ts
@@ -708,12 +708,12 @@ describe('complex', () => {
       TestTupleValidationParams
     > {
       constructor() {
-        super(
+        super([
           ti.nested(
             new TestStringValidator(),
             (params_) => params_?.stringParams
           )
-        );
+        ]);
       }
     }
 

--- a/tests/code/complex.test.ts
+++ b/tests/code/complex.test.ts
@@ -576,8 +576,10 @@ describe('complex', () => {
     > {
       constructor() {
         super({
-          data: (validateWith_, params_) =>
-            validateWith_(new TestStringValidator(), params_?.dataParams)
+          data: ti.nested(
+            new TestStringValidator(),
+            (params_) => params_?.dataParams
+          )
         });
       }
     }
@@ -607,8 +609,11 @@ describe('complex', () => {
       TestArrayValidationParams
     > {
       constructor() {
-        super((validateWith_, params_) =>
-          validateWith_(new TestStringValidator(), params_?.stringParams)
+        super(
+          ti.nested(
+            new TestStringValidator(),
+            (params_) => params_?.stringParams
+          )
         );
       }
     }
@@ -634,8 +639,11 @@ describe('complex', () => {
       TestDictionaryValidationParams
     > {
       constructor() {
-        super((validateWith_, params_) =>
-          validateWith_(new TestStringValidator(), params_?.stringParams)
+        super(
+          ti.nested(
+            new TestStringValidator(),
+            (params_) => params_?.stringParams
+          )
         );
       }
     }
@@ -667,8 +675,10 @@ describe('complex', () => {
     > {
       constructor() {
         super({
-          data: (validateWith_, params_) =>
-            validateWith_(new TestStringValidator(), params_?.dataParams)
+          data: ti.nested(
+            new TestStringValidator(),
+            (params_) => params_?.dataParams
+          )
         });
       }
     }
@@ -698,8 +708,11 @@ describe('complex', () => {
       TestTupleValidationParams
     > {
       constructor() {
-        super((validateWith_, params_) =>
-          validateWith_(new TestStringValidator(), params_?.stringParams)
+        super(
+          ti.nested(
+            new TestStringValidator(),
+            (params_) => params_?.stringParams
+          )
         );
       }
     }

--- a/tests/code/validOr.test.ts
+++ b/tests/code/validOr.test.ts
@@ -1,0 +1,18 @@
+import { TypeInspector } from '@/inspector.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe('validOrDefault / validOrFallback', () => {
+  test('validOrDefault returns the value when valid, else undefined', () => {
+    expect.assertions(2);
+    expect(ti.number.validOrDefault(42)).toBe(42);
+    expect(ti.number.validOrDefault('nope')).toBeUndefined();
+  });
+
+  test('validOrFallback returns the value when valid, else the fallback', () => {
+    expect.assertions(2);
+    expect(ti.number.validOrFallback(42, 0)).toBe(42);
+    expect(ti.number.validOrFallback('nope', 0)).toBe(0);
+  });
+});

--- a/tests/code/validator/any.test.ts
+++ b/tests/code/validator/any.test.ts
@@ -19,6 +19,12 @@ describe(DefaultAnyValidator, () => {
     expect(ti.any.isValid(NaN)).toBe(true);
   });
 
+  test('isValid - correct conditions', () => {
+    expect.assertions(2);
+    expect(ti.any.notNullish.isValid(42)).toBe(true);
+    expect(ti.any.notFalsy.isValid(42)).toBe(true);
+  });
+
   test('isValid - incorrect conditions', () => {
     expect.assertions(4);
     expect(ti.any.notNullish.isValid(undefined)).toBe(false);

--- a/tests/code/validator/bigint.test.ts
+++ b/tests/code/validator/bigint.test.ts
@@ -1,0 +1,46 @@
+import { TypeInspector } from '@/inspector.js';
+import { DefaultBigIntValidator } from '@/validator/bigint.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe(DefaultBigIntValidator, () => {
+  test('isValid - success', () => {
+    expect.assertions(3);
+    expect(ti.bigint.isValid(42n)).toBe(true);
+    expect(ti.bigint.isValid(0n)).toBe(true);
+    expect(ti.bigint.isValid(-42n)).toBe(true);
+  });
+
+  test('isValid - failure', () => {
+    expect.assertions(5);
+    expect(ti.bigint.isValid(undefined)).toBe(false);
+    expect(ti.bigint.isValid(null)).toBe(false);
+    expect(ti.bigint.isValid(42)).toBe(false);
+    expect(ti.bigint.isValid('42')).toBe(false);
+    expect(ti.bigint.isValid({ oh: 'no' })).toBe(false);
+  });
+
+  test('isValid - correct conditions', () => {
+    expect.assertions(7);
+    expect(ti.bigint.positive.isValid(42n)).toBe(true);
+    expect(ti.bigint.negative.isValid(-42n)).toBe(true);
+    expect(ti.bigint.rejectZero.isValid(42n)).toBe(true);
+    expect(ti.bigint.min(-42n).max(42n).isValid(42n)).toBe(true);
+    expect(ti.bigint.min(-42n).max(42n).isValid(-42n)).toBe(true);
+    expect(ti.bigint.accept(42n, -42n).isValid(42n)).toBe(true);
+    expect(ti.bigint.reject(-42n).isValid(42n)).toBe(true);
+  });
+
+  test('isValid - incorrect conditions', () => {
+    expect.assertions(8);
+    expect(ti.bigint.positive.isValid(0n)).toBe(false);
+    expect(ti.bigint.positive.isValid(-42n)).toBe(false);
+    expect(ti.bigint.negative.isValid(0n)).toBe(false);
+    expect(ti.bigint.rejectZero.isValid(0n)).toBe(false);
+    expect(ti.bigint.min(-42n).max(42n).isValid(-43n)).toBe(false);
+    expect(ti.bigint.min(-42n).max(42n).isValid(43n)).toBe(false);
+    expect(ti.bigint.accept(-42n).isValid(42n)).toBe(false);
+    expect(ti.bigint.reject(42n).isValid(42n)).toBe(false);
+  });
+});

--- a/tests/code/validator/enum.test.ts
+++ b/tests/code/validator/enum.test.ts
@@ -25,8 +25,10 @@ const ti = new TypeInspector();
 
 describe(DefaultEnumValidator, () => {
   test('isValid - success', () => {
-    expect.assertions(9);
+    expect.assertions(10);
     expect(ti.enum(NumberEnum).isValid(0)).toBe(true);
+    // string enum with allowFlags=true: flag scan skips non-number values
+    expect(ti.enum(StringEnum, true).isValid('a')).toBe(true);
     expect(ti.enum(NumberEnum).isValid(1)).toBe(true);
     expect(ti.enum(NumberEnum).isValid(2)).toBe(true);
     expect(ti.enum(StringEnum).isValid('a')).toBe(true);

--- a/tests/code/validator/instance.test.ts
+++ b/tests/code/validator/instance.test.ts
@@ -1,0 +1,34 @@
+import { TypeInspector } from '@/inspector.js';
+import { DefaultInstanceValidator } from '@/validator/instance.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+class Animal {
+  public legs = 4;
+}
+
+class Dog extends Animal {
+  public bark(): string {
+    return 'woof';
+  }
+}
+
+describe(DefaultInstanceValidator, () => {
+  test('isValid - success', () => {
+    expect.assertions(4);
+    expect(ti.instance(Animal).isValid(new Animal())).toBe(true);
+    expect(ti.instance(Animal).isValid(new Dog())).toBe(true); // subclass
+    expect(ti.instance(Dog).isValid(new Dog())).toBe(true);
+    expect(ti.instance(Date).isValid(new Date())).toBe(true);
+  });
+
+  test('isValid - failure', () => {
+    expect.assertions(5);
+    expect(ti.instance(Dog).isValid(new Animal())).toBe(false); // superclass
+    expect(ti.instance(Animal).isValid({})).toBe(false);
+    expect(ti.instance(Animal).isValid(null)).toBe(false);
+    expect(ti.instance(Animal).isValid(undefined)).toBe(false);
+    expect(ti.instance(Date).isValid('2021-01-01')).toBe(false);
+  });
+});

--- a/tests/code/validator/lazy.test.ts
+++ b/tests/code/validator/lazy.test.ts
@@ -1,0 +1,40 @@
+import { TypeInspector } from '@/inspector.js';
+import type { Validator } from '@/types.js';
+import { DefaultLazyValidator } from '@/validator/lazy.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+interface TreeNode {
+  value: number;
+  children: TreeNode[];
+}
+
+describe(DefaultLazyValidator, () => {
+  test('isValid - recursive schema', () => {
+    expect.assertions(2);
+    const treeValidator: Validator<TreeNode> = ti.object<TreeNode>({
+      value: ti.number,
+      children: ti.array(ti.lazy(() => treeValidator))
+    });
+
+    expect(
+      treeValidator.isValid({
+        value: 1,
+        children: [{ value: 2, children: [{ value: 3, children: [] }] }]
+      })
+    ).toBe(true);
+    expect(
+      treeValidator.isValid({
+        value: 1,
+        children: [{ value: 'nope', children: [] }]
+      })
+    ).toBe(false);
+  });
+
+  test('isValid - simple delegation + failure', () => {
+    expect.assertions(2);
+    expect(ti.lazy(() => ti.string).isValid('hello')).toBe(true);
+    expect(ti.lazy(() => ti.string).isValid(42)).toBe(false);
+  });
+});

--- a/tests/code/validator/map.test.ts
+++ b/tests/code/validator/map.test.ts
@@ -47,4 +47,26 @@ describe(DefaultMapValidator, () => {
     const objectKeyMap = new Map<unknown, unknown>([[{}, 'not a number']]);
     expect(() => ti.map(ti.any, ti.number).validate(objectKeyMap)).toThrow();
   });
+
+  test('aggregate collects invalid keys', () => {
+    expect.assertions(2);
+    const validator = ti.map(ti.number, ti.number).aggregate;
+    expect(
+      validator.isValid(
+        new Map<unknown, number>([
+          ['a', 1],
+          ['b', 2]
+        ])
+      )
+    ).toBe(false);
+    expect(validator.validationError?.subErrors?.length).toBe(2);
+  });
+
+  test('aggregate collects invalid value of an object key (no trace)', () => {
+    expect.assertions(1);
+    const validator = ti.map(ti.any, ti.number).aggregate;
+    expect(
+      validator.isValid(new Map<unknown, unknown>([[{}, 'not a number']]))
+    ).toBe(false);
+  });
 });

--- a/tests/code/validator/map.test.ts
+++ b/tests/code/validator/map.test.ts
@@ -1,0 +1,50 @@
+import { TypeInspector } from '@/inspector.js';
+import { DefaultMapValidator } from '@/validator/map.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe(DefaultMapValidator, () => {
+  test('isValid - success', () => {
+    expect.assertions(2);
+    expect(
+      ti.map(ti.string, ti.number).isValid(
+        new Map([
+          ['a', 1],
+          ['b', 2]
+        ])
+      )
+    ).toBe(true);
+    // mixed key types exercise the key-trace branches (string/number/symbol)
+    expect(
+      ti.map(ti.any, ti.number).isValid(
+        new Map<unknown, number>([
+          ['s', 1],
+          [2, 2],
+          [Symbol('x'), 3]
+        ])
+      )
+    ).toBe(true);
+  });
+
+  test('isValid - failure', () => {
+    expect.assertions(5);
+    expect(ti.map(ti.string, ti.number).isValid(undefined)).toBe(false);
+    expect(ti.map(ti.string, ti.number).isValid({})).toBe(false);
+    expect(ti.map(ti.string, ti.number).isValid([])).toBe(false);
+    // invalid value (primitive key -> traced)
+    expect(
+      ti.map(ti.string, ti.number).isValid(new Map([['a', 'nope']]))
+    ).toBe(false);
+    // invalid key
+    expect(
+      ti.map(ti.string, ti.number).isValid(new Map([[1, 1]]))
+    ).toBe(false);
+  });
+
+  test('validate - object key uses no trace', () => {
+    expect.assertions(1);
+    const objectKeyMap = new Map<unknown, unknown>([[{}, 'not a number']]);
+    expect(() => ti.map(ti.any, ti.number).validate(objectKeyMap)).toThrow();
+  });
+});

--- a/tests/code/validator/nested.test.ts
+++ b/tests/code/validator/nested.test.ts
@@ -1,0 +1,54 @@
+import { DefaultObjectValidator, DefaultStringValidator } from '@/index.js';
+import { TypeInspector } from '@/inspector.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+type ChildParams = { notEmpty?: boolean };
+
+class SpecialString extends DefaultStringValidator<ChildParams> {
+  constructor() {
+    super();
+    this.custom((value_, params_) =>
+      params_?.notEmpty && value_ === '' ? 'empty is not allowed' : undefined
+    );
+  }
+}
+
+type ParentParams = { stringParams?: ChildParams };
+
+class WithParams extends DefaultObjectValidator<{ test: string }, ParentParams> {
+  constructor() {
+    super({
+      test: ti.nested(
+        new SpecialString(),
+        (parentParams_) => parentParams_?.stringParams
+      )
+    });
+  }
+}
+
+describe('ti.nested', () => {
+  test('forwards + maps the parent params to the wrapped validator', () => {
+    expect.assertions(4);
+    const validator = new WithParams();
+    expect(validator.isValid({ test: '' })).toBe(true); // no params
+    expect(validator.isValid({ test: '' }, {})).toBe(true); // notEmpty unset
+    expect(
+      validator.isValid({ test: '' }, { stringParams: { notEmpty: true } })
+    ).toBe(false);
+    expect(
+      validator.isValid({ test: 'x' }, { stringParams: { notEmpty: true } })
+    ).toBe(true);
+  });
+
+  test('reports the failing property path', () => {
+    expect.assertions(1);
+    expect(() =>
+      new WithParams().validate(
+        { test: '' },
+        { stringParams: { notEmpty: true } }
+      )
+    ).toThrow('test');
+  });
+});

--- a/tests/code/validator/number.test.ts
+++ b/tests/code/validator/number.test.ts
@@ -28,7 +28,7 @@ describe(DefaultNumberValidator, () => {
   });
 
   test('isValid - correct conditions', () => {
-    expect.assertions(14);
+    expect.assertions(17);
     expect(ti.number.positive.isValid(42)).toBe(true);
     expect(ti.number.negative.isValid(-42)).toBe(true);
     expect(ti.number.rejectZero.isValid(42)).toBe(true);
@@ -47,10 +47,13 @@ describe(DefaultNumberValidator, () => {
         .isValid(42)
     ).toBe(true);
     expect(ti.number.finite.isValid(42)).toBe(true);
+    expect(ti.number.integer.isValid(42)).toBe(true);
+    expect(ti.number.safeInteger.isValid(42)).toBe(true);
+    expect(ti.number.multipleOf(7).isValid(42)).toBe(true);
   });
 
   test('isValid - incorrect conditions', () => {
-    expect.assertions(15);
+    expect.assertions(18);
     expect(ti.number.positive.isValid(-42)).toBe(false);
     expect(ti.number.negative.isValid(42)).toBe(false);
     expect(ti.number.rejectZero.isValid(0)).toBe(false);
@@ -70,5 +73,10 @@ describe(DefaultNumberValidator, () => {
         .isValid(42)
     ).toBe(false);
     expect(ti.number.finite.isValid(Infinity)).toBe(false);
+    expect(ti.number.integer.isValid(42.5)).toBe(false);
+    expect(ti.number.safeInteger.isValid(Number.MAX_SAFE_INTEGER + 1)).toBe(
+      false
+    );
+    expect(ti.number.multipleOf(5).isValid(42)).toBe(false);
   });
 });

--- a/tests/code/validator/object.test.ts
+++ b/tests/code/validator/object.test.ts
@@ -227,6 +227,14 @@ describe(DefaultObjectValidator, () => {
     ).toBe(false);
   });
 
+  test('isValid - rejectArray', () => {
+    expect.assertions(3);
+    // without rejectArray an array passes the object base check
+    expect(ti.object({}).isValid([])).toBe(true);
+    expect(ti.object({}).rejectArray.isValid([])).toBe(false);
+    expect(ti.object({}).rejectArray.isValid({})).toBe(true);
+  });
+
   test('validate - success', () => {
     expect.assertions(2);
     expect(() =>

--- a/tests/code/validator/partial.test.ts
+++ b/tests/code/validator/partial.test.ts
@@ -6,7 +6,7 @@ const ti = new TypeInspector();
 
 describe(DefaultObjectValidator, () => {
   test('isValid - success', () => {
-    expect.assertions(2);
+    expect.assertions(3);
     expect(
       ti
         .partial({
@@ -29,6 +29,11 @@ describe(DefaultObjectValidator, () => {
 
     expect(
       ti.partial({ test: ti.string }).isValid({ test: 'hello', test2: 'world' })
+    ).toBe(true);
+
+    // a property with no validator (undefined) is skipped
+    expect(
+      ti.partial<{ a: string }>({ a: undefined }).isValid({ a: 123 })
     ).toBe(true);
   });
 

--- a/tests/code/validator/properties.test.ts
+++ b/tests/code/validator/properties.test.ts
@@ -1,0 +1,42 @@
+import { TypeInspector } from '@/inspector.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe('prop / props', () => {
+  test('object: prop returns the exact validator that was defined', () => {
+    expect.assertions(3);
+    const nameValidator = ti.string;
+    const ageValidator = ti.number;
+    const validator = ti.object({ name: nameValidator, age: ageValidator });
+
+    expect(validator.prop('name')).toBe(nameValidator);
+    expect(validator.prop('age')).toBe(ageValidator);
+    expect(validator.props()).toEqual({
+      name: nameValidator,
+      age: ageValidator
+    });
+  });
+
+  test('partial: prop returns the defined validator or undefined', () => {
+    expect.assertions(2);
+    const nameValidator = ti.string;
+    const validator = ti.partial<{ name: string; age: number }>({
+      name: nameValidator
+    });
+
+    expect(validator.prop('name')).toBe(nameValidator);
+    expect(validator.prop('age')).toBeUndefined();
+  });
+
+  test('the retrieved validator is the real instance (usable after narrowing)', () => {
+    expect.assertions(2);
+    const nameValidator = ti.string.shortest(2);
+    const validator = ti.object({ name: nameValidator });
+
+    // prop returns PropertyValidator<...> (Validator | nested descriptor); when
+    // it is a plain validator it is the exact instance and stays usable
+    expect(validator.prop('name')).toBe(nameValidator);
+    expect(nameValidator.isValid('x')).toBe(false);
+  });
+});

--- a/tests/code/validator/properties.test.ts
+++ b/tests/code/validator/properties.test.ts
@@ -18,6 +18,17 @@ describe('prop / props', () => {
     });
   });
 
+  test('object: prop resolves to the precise validator type', () => {
+    expect.assertions(2);
+    const validator = ti.object({ name: ti.string, age: ti.number });
+
+    const nameValidator = validator.prop('name');
+    const ageValidator = validator.prop('age');
+
+    expect(nameValidator.shortest(2).isValid('x')).toBe(false);
+    expect(ageValidator.positive.isValid(-1)).toBe(false);
+  });
+
   test('partial: prop returns the defined validator or undefined', () => {
     expect.assertions(2);
     const nameValidator = ti.string;
@@ -34,8 +45,6 @@ describe('prop / props', () => {
     const nameValidator = ti.string.shortest(2);
     const validator = ti.object({ name: nameValidator });
 
-    // prop returns PropertyValidator<...> (Validator | nested descriptor); when
-    // it is a plain validator it is the exact instance and stays usable
     expect(validator.prop('name')).toBe(nameValidator);
     expect(nameValidator.isValid('x')).toBe(false);
   });

--- a/tests/code/validator/set.test.ts
+++ b/tests/code/validator/set.test.ts
@@ -1,0 +1,30 @@
+import { TypeInspector } from '@/inspector.js';
+import { DefaultSetValidator } from '@/validator/set.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe(DefaultSetValidator, () => {
+  test('isValid - success', () => {
+    expect.assertions(2);
+    expect(ti.set(ti.number).isValid(new Set([1, 2, 3]))).toBe(true);
+    expect(ti.set(ti.string).isValid(new Set(['a', 'b']))).toBe(true);
+  });
+
+  test('isValid - failure', () => {
+    expect.assertions(4);
+    expect(ti.set(ti.number).isValid(undefined)).toBe(false);
+    expect(ti.set(ti.number).isValid({})).toBe(false);
+    expect(ti.set(ti.number).isValid([1, 2, 3])).toBe(false);
+    expect(
+      ti.set(ti.number).isValid(new Set<unknown>([1, 'nope', 3]))
+    ).toBe(false);
+  });
+
+  test('validate - reports item index in path', () => {
+    expect.assertions(1);
+    expect(() =>
+      ti.set(ti.number).validate(new Set<unknown>([1, 'nope']))
+    ).toThrow('1');
+  });
+});

--- a/tests/code/validator/string.test.ts
+++ b/tests/code/validator/string.test.ts
@@ -24,7 +24,7 @@ describe(DefaultStringValidator, () => {
   });
 
   test('isValid - correct conditions', () => {
-    expect.assertions(26);
+    expect.assertions(29);
     expect(ti.string.length(5).isValid('hello')).toBe(true);
     expect(ti.string.length(5).longest(6).isValid('hello')).toBe(true);
     expect(ti.string.length(5).shortest(4).isValid('hello')).toBe(true);
@@ -79,10 +79,14 @@ describe(DefaultStringValidator, () => {
     expect(ti.string.url.isValid('http://www.ietf.org/rfc/rfc2396.txt')).toBe(
       true
     );
+
+    expect(ti.string.startsWith('hel').isValid('hello')).toBe(true);
+    expect(ti.string.endsWith('llo').isValid('hello')).toBe(true);
+    expect(ti.string.includes('ell').isValid('hello')).toBe(true);
   });
 
   test('isValid - incorrect conditions', () => {
-    expect.assertions(32);
+    expect.assertions(35);
     expect(ti.string.length(6).isValid('hello')).toBe(false);
     expect(ti.string.length(5).longest(4).isValid('hello')).toBe(false);
     expect(ti.string.length(5).shortest(6).isValid('hello')).toBe(false);
@@ -146,5 +150,9 @@ describe(DefaultStringValidator, () => {
     );
     expect(ti.string.uri.isValid('tel+1-816-555-1212')).toBe(false);
     expect(ti.string.uri.isValid('telnet//192.0.2.16:80/')).toBe(false);
+
+    expect(ti.string.startsWith('xyz').isValid('hello')).toBe(false);
+    expect(ti.string.endsWith('xyz').isValid('hello')).toBe(false);
+    expect(ti.string.includes('xyz').isValid('hello')).toBe(false);
   });
 });

--- a/tests/code/validator/string.test.ts
+++ b/tests/code/validator/string.test.ts
@@ -24,7 +24,7 @@ describe(DefaultStringValidator, () => {
   });
 
   test('isValid - correct conditions', () => {
-    expect.assertions(29);
+    expect.assertions(30);
     expect(ti.string.length(5).isValid('hello')).toBe(true);
     expect(ti.string.length(5).longest(6).isValid('hello')).toBe(true);
     expect(ti.string.length(5).shortest(4).isValid('hello')).toBe(true);
@@ -83,6 +83,7 @@ describe(DefaultStringValidator, () => {
     expect(ti.string.startsWith('hel').isValid('hello')).toBe(true);
     expect(ti.string.endsWith('llo').isValid('hello')).toBe(true);
     expect(ti.string.includes('ell').isValid('hello')).toBe(true);
+    expect(ti.string.rejectEmpty.isValid('hello')).toBe(true);
   });
 
   test('isValid - incorrect conditions', () => {

--- a/tests/code/validator/symbol.test.ts
+++ b/tests/code/validator/symbol.test.ts
@@ -1,0 +1,22 @@
+import { TypeInspector } from '@/inspector.js';
+import { DefaultSymbolValidator } from '@/validator/symbol.js';
+import { describe, expect, test } from 'vitest';
+
+const ti = new TypeInspector();
+
+describe(DefaultSymbolValidator, () => {
+  test('isValid - success', () => {
+    expect.assertions(2);
+    expect(ti.symbol.isValid(Symbol('test'))).toBe(true);
+    expect(ti.symbol.isValid(Symbol.iterator)).toBe(true);
+  });
+
+  test('isValid - failure', () => {
+    expect.assertions(5);
+    expect(ti.symbol.isValid(undefined)).toBe(false);
+    expect(ti.symbol.isValid(null)).toBe(false);
+    expect(ti.symbol.isValid('symbol')).toBe(false);
+    expect(ti.symbol.isValid(42)).toBe(false);
+    expect(ti.symbol.isValid({ oh: 'no' })).toBe(false);
+  });
+});

--- a/tests/testTypes.ts
+++ b/tests/testTypes.ts
@@ -28,7 +28,7 @@ export class ExtendedValidationParametersValidator extends DefaultValidator<
 
   protected validateBaseType(
     value_: unknown,
-    params_?: TestExtendedValidationParameters | undefined
+    params_?: TestExtendedValidationParameters
   ): unknown {
     if (params_?.failOn === 'validate') {
       this.throwValidationError('extended failure on validate');


### PR DESCRIPTION
- new validators:
  - bigint
  - symbol
  - instance
  - map
  - set
  - lazy (for recursive/self-referential types)
  - nested (pass validation parameters from the parent element to the child validator - e.g. object, map, tuple ...)
- new base features:
  - validateOrDefault
  - validateOrFallback
  - aggregate (collect all errors)
  - prop (get prop validator - e.g. from object validator)
  - props (get all prop validators)
- extended validator:
  - string:
    - startsWith
    - endsWith
    - includes
  - number:
    - integer
    - safeInteger
    - multipleOf
  - object:
    - rejectArray 